### PR TITLE
ci: add GitHub Container Registry publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,55 @@
+name: Publish Container
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that builds and publishes multi-arch (amd64/arm64) container images to `ghcr.io/dhirmadi/google-workspace-mcp-go`
- Triggers on pushes to `main` (rolling `:main` tag) and version tags like `v1.2.3` (semantic version tags)
- Uses `docker/metadata-action` for automatic tag generation and the built-in `GITHUB_TOKEN` for authentication — no extra secrets needed

## Test plan
- [ ] Merge PR and verify the workflow runs successfully on the `main` push trigger
- [ ] Confirm the container image appears under the repo's **Packages** tab
- [ ] Pull the image: `docker pull ghcr.io/dhirmadi/google-workspace-mcp-go:main`
- [ ] (Later) Push a version tag and verify semver tags are created

Made with [Cursor](https://cursor.com)