### PR TITLE
fix: expose Gmail attachment metadata, add folder_id to import, improve 403 errors

### DIFF
--- a/internal/tools/gmail/handlers.go
+++ b/internal/tools/gmail/handlers.go
@@ -136,6 +136,14 @@ func createGetMessageContentHandler(factory *services.Factory) mcp.ToolHandlerFo
 		if detail.MessageID != "" {
 			rb.KeyValue("Message-ID Header", detail.MessageID)
 		}
+		if len(detail.Attachments) > 0 {
+			rb.Blank()
+			rb.Section("Attachments")
+			for _, a := range detail.Attachments {
+				rb.Item("%s (%s, %d bytes)", a.Filename, a.MimeType, a.Size)
+				rb.Line("    Attachment ID: %s", a.AttachmentID)
+			}
+		}
 		rb.Blank()
 		rb.Section("Body")
 		rb.Raw(detail.Body)
@@ -211,6 +219,12 @@ func createBatchGetMessagesHandler(factory *services.Factory) mcp.ToolHandlerFor
 			rb.KeyValue("From", m.From)
 			rb.KeyValue("Date", m.Date)
 			rb.KeyValue("ID", m.ID)
+			if len(m.Attachments) > 0 {
+				rb.KeyValue("Attachments", len(m.Attachments))
+				for _, a := range m.Attachments {
+					rb.Line("    • %s (%s, %d bytes) — ID: %s", a.Filename, a.MimeType, a.Size, a.AttachmentID)
+				}
+			}
 			rb.Blank()
 			rb.Raw(m.Body)
 			rb.Blank()

--- a/internal/tools/gmail/handlers_extended.go
+++ b/internal/tools/gmail/handlers_extended.go
@@ -94,6 +94,12 @@ func createGetThreadHandler(factory *services.Factory) mcp.ToolHandlerFor[GetThr
 			rb.KeyValue("Subject", detail.Subject)
 			rb.KeyValue("From", detail.From)
 			rb.KeyValue("Date", detail.Date)
+			if len(detail.Attachments) > 0 {
+				rb.KeyValue("Attachments", len(detail.Attachments))
+				for _, a := range detail.Attachments {
+					rb.Line("    • %s (%s, %d bytes) — ID: %s", a.Filename, a.MimeType, a.Size, a.AttachmentID)
+				}
+			}
 			rb.Blank()
 			rb.Raw(detail.Body)
 			rb.Blank()


### PR DESCRIPTION
## Summary\n\nAddresses three issues discovered during end-to-end MCP tool testing:\n\n- **Gmail attachment metadata**: `get_gmail_message_content` now surfaces attachment info (filename, MIME type, size, attachment ID) so that `get_gmail_attachment_content` is actually usable. Previously there was no way to discover attachment IDs. Also updated `get_gmail_messages_content_batch` and `get_gmail_thread_content` to include attachment info.\n- **`import_to_google_doc` folder_id**: Added an optional `folder_id` parameter so users can specify a destination folder they own. Fixes failures when importing shared files where the source parent folder is not writable.\n- **Clearer 403 error messages**: 403 errors from Google Workspace admin policy restrictions (e.g. sharing outside domain disabled) now return a specific message about org policy instead of the generic \"re-authenticate with broader scopes\" message.\n\n## Changes\n\n| File | Change |\n|------|--------|\n| `internal/tools/gmail/helpers.go` | Added `AttachmentInfo` struct, `extractAttachments()` function, updated `MessageDetail` and `messageToDetail()` |\n| `internal/tools/gmail/handlers.go` | Render attachments section in `get_gmail_message_content` and batch handler |\n| `internal/tools/gmail/handlers_extended.go` | Render attachments in `get_gmail_thread_content` |\n| `internal/tools/gmail/helpers_test.go` | 5 new tests for attachment extraction |\n| `internal/tools/drive/handlers.go` | Added `folder_id` param to `ImportToDocInput`, updated handler logic |\n| `internal/middleware/errors.go` | Pattern-match 403 errors for org policy restrictions |\n\n## Test plan\n\n- [x] `go build ./...` passes\n- [x] `go test ./...` passes (all existing + 5 new tests)\n- [x] End-to-end tested all 37 exposed MCP tools against live Google Workspace account\n- [ ] Rebuild container and verify `get_gmail_message_content` shows attachments on messages with attachments\n- [ ] Verify `import_to_google_doc` with explicit `folder_id` works on shared files"