### PR TITLE
fix: MCP OAuth visibility, OAuth success UI, Gmail subject headers

### DIFF
--- a/internal/auth/callback.go
+++ b/internal/auth/callback.go
@@ -12,6 +12,9 @@ type ClientInvalidator interface {
 	InvalidateClient(userEmail string)
 }
 
+// Seconds before the OAuth success page attempts window.close() (browsers may block auto-close).
+const oauthSuccessAutoCloseSeconds = 30
+
 // OAuthCallbackHandler returns an http.HandlerFunc that handles the OAuth 2.0 callback.
 // It exchanges the authorization code for a token and persists it.
 // The state parameter carries the user's email address.
@@ -82,6 +85,7 @@ func OAuthCallbackHandler(oauthMgr *OAuthManager, invalidator ClientInvalidator)
 }
 
 func renderSuccessPage(email string) string {
+	safeEmail := html.EscapeString(email)
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -150,8 +154,30 @@ func renderSuccessPage(email string) string {
       letter-spacing: 0.5px;
       text-transform: uppercase;
     }
+    .countdown-wrap {
+      margin-top: 28px;
+      padding-top: 24px;
+      border-top: 1px solid #444;
+    }
+    .countdown-msg {
+      font-size: 14px;
+      color: #aaa;
+      margin-bottom: 8px;
+    }
+    .countdown {
+      font-size: 42px;
+      font-weight: 700;
+      color: #4caf50;
+      font-variant-numeric: tabular-nums;
+      line-height: 1.2;
+    }
+    .countdown-unit {
+      font-size: 13px;
+      color: #666;
+      margin-top: 4px;
+    }
     .close-hint {
-      margin-top: 24px;
+      margin-top: 16px;
       font-size: 13px;
       color: #666;
     }
@@ -169,10 +195,39 @@ func renderSuccessPage(email string) string {
       All MCP tools are now available for this account.
     </p>
     <span class="badge">Google Workspace MCP</span>
-    <p class="close-hint">You can close this window.</p>
+    <div class="countdown-wrap">
+      <p class="countdown-msg" id="countdown-msg">This window will close automatically in</p>
+      <div class="countdown" id="countdown">%[2]d</div>
+      <p class="countdown-unit">seconds</p>
+      <p class="close-hint" id="close-fallback"></p>
+    </div>
   </div>
+  <script>
+    (function () {
+      var total = %[2]d;
+      var remaining = total;
+      var el = document.getElementById("countdown");
+      var msg = document.getElementById("countdown-msg");
+      var fallback = document.getElementById("close-fallback");
+      function tick() {
+        if (el) el.textContent = String(remaining);
+        if (remaining <= 0) {
+          if (msg) msg.textContent = "Closing…";
+          window.close();
+          if (fallback) {
+            fallback.textContent =
+              "This tab could not be closed automatically (browser security). You may close it yourself.";
+          }
+          return;
+        }
+        remaining--;
+        setTimeout(tick, 1000);
+      }
+      tick();
+    })();
+  </script>
 </body>
-</html>`, email)
+</html>`, safeEmail, oauthSuccessAutoCloseSeconds)
 }
 
 func renderErrorPage(errMsg string) string {

--- a/internal/middleware/errors.go
+++ b/internal/middleware/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 
@@ -13,6 +14,15 @@ import (
 func HandleGoogleAPIError(err error) error {
 	if err == nil {
 		return nil
+	}
+
+	var retrieveErr *oauth2.RetrieveError
+	if errors.As(err, &retrieveErr) {
+		return fmt.Errorf(
+			"google oauth token error — refresh or consent may be invalid (%s). "+
+				"Call start_google_auth for this user; if the client hides the link, copy the URL from this MCP server's stderr / MCP logs output",
+			retrieveErr.Error(),
+		)
 	}
 
 	var googleErr *googleapi.Error
@@ -25,7 +35,7 @@ func HandleGoogleAPIError(err error) error {
 		case 401:
 			return fmt.Errorf(
 				"authentication expired for this user — call start_google_auth tool to re-authenticate, " +
-					"or verify the OAuth configuration is correct")
+					"or verify the OAuth configuration is correct. If the host hides tool text, use the OAuth URL printed to this server's stderr / MCP logs")
 		case 403:
 			msg := googleErr.Message
 			lower := strings.ToLower(msg)

--- a/internal/tools/auth/auth.go
+++ b/internal/tools/auth/auth.go
@@ -4,6 +4,9 @@ package auth
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
+	"os"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -35,10 +38,25 @@ type StartAuthInput struct {
 	UserEmail string `json:"user_google_email" jsonschema:"required" jsonschema_description:"The user's Google email address to authenticate"`
 }
 
-func createStartAuthHandler(oauthMgr *iauth.OAuthManager) mcp.ToolHandlerFor[StartAuthInput, any] {
-	return func(ctx context.Context, req *mcp.CallToolRequest, input StartAuthInput) (*mcp.CallToolResult, any, error) {
+// StartAuthOutput exposes the authorization URL for MCP clients that surface structuredContent
+// more reliably than plain tool text (some hosts hide long URLs in chat).
+type StartAuthOutput struct {
+	AuthURL   string `json:"auth_url"`
+	UserEmail string `json:"user_google_email"`
+}
+
+func createStartAuthHandler(oauthMgr *iauth.OAuthManager) mcp.ToolHandlerFor[StartAuthInput, StartAuthOutput] {
+	return func(ctx context.Context, req *mcp.CallToolRequest, input StartAuthInput) (*mcp.CallToolResult, StartAuthOutput, error) {
 		// Generate auth URL with user email as state
 		authURL := oauthMgr.GetAuthURL(input.UserEmail)
+
+		// Duplicate on stderr: stdio MCP uses stdout for the protocol; Cursor and similar clients
+		// often show MCP server stderr in logs while hiding tool output in the chat UI.
+		slog.Warn("google oauth authorization URL issued — copy from stderr/MCP logs if the client hides tool text",
+			"user_google_email", input.UserEmail,
+			"auth_url", authURL,
+		)
+		fmt.Fprintf(os.Stderr, "\n[google-workspace-mcp] OAuth URL (open in browser). If your client hides tool results, copy from here or MCP server logs:\n%s\n\n", authURL)
 
 		rb := response.New()
 		rb.Header("Google Authentication")
@@ -48,7 +66,9 @@ func createStartAuthHandler(oauthMgr *iauth.OAuthManager) mcp.ToolHandlerFor[Sta
 		rb.Blank()
 		rb.Line("After granting access, the OAuth callback will automatically capture the authorization code.")
 		rb.Line("Authenticating as: %s", input.UserEmail)
+		rb.Blank()
+		rb.Line("If you do not see a clickable link above, open the MCP server output / stderr for the same URL.")
 
-		return rb.TextResult(), nil, nil
+		return rb.TextResult(), StartAuthOutput{AuthURL: authURL, UserEmail: input.UserEmail}, nil
 	}
 }

--- a/internal/tools/gmail/helpers.go
+++ b/internal/tools/gmail/helpers.go
@@ -197,33 +197,58 @@ func messageToDetail(msg *gmail.Message) MessageDetail {
 	}
 }
 
+// sanitizeOneLineHeaderValue strips a UTF-8 BOM and removes CR/LF/NUL so header
+// values cannot break RFC 5322 structure (which would garble the Subject line).
+func sanitizeOneLineHeaderValue(s string) string {
+	s = strings.TrimPrefix(s, "\ufeff")
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\r', '\n', 0:
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// formatSubjectHeader encodes the Subject for RFC 5322 + RFC 2047. Raw UTF-8 in
+// Subject (or a BOM pasted from documents) is a common cause of mojibake or
+// leading garbage in mail clients.
+func formatSubjectHeader(subject string) string {
+	return mime.QEncoding.Encode("UTF-8", sanitizeOneLineHeaderValue(subject))
+}
+
 // buildRawMessage constructs an RFC 2822 message and returns it as a
 // base64url-encoded string suitable for the Gmail API's raw field.
 //
 // Encoding details:
-//   - Subject is RFC 2047 Q-encoded so non-ASCII characters survive transit.
+//   - Subject is RFC 2047 Q-encoded (after BOM/control sanitization).
 //   - Body is declared Content-Transfer-Encoding: 8bit with charset UTF-8,
 //     which tells receiving MTAs to expect raw UTF-8 octets.
 func buildRawMessage(to, subject, body, cc, bcc, threadID, inReplyTo, references string) string {
 	var msg strings.Builder
 
-	// RFC 2047 Q-encoding for headers that may contain non-ASCII characters.
-	enc := mime.QEncoding
-
-	msg.WriteString(fmt.Sprintf("To: %s\r\n", to))
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", sanitizeOneLineHeaderValue(to)))
 	if cc != "" {
-		msg.WriteString(fmt.Sprintf("Cc: %s\r\n", cc))
+		msg.WriteString(fmt.Sprintf("Cc: %s\r\n", sanitizeOneLineHeaderValue(cc)))
 	}
 	if bcc != "" {
-		msg.WriteString(fmt.Sprintf("Bcc: %s\r\n", bcc))
+		msg.WriteString(fmt.Sprintf("Bcc: %s\r\n", sanitizeOneLineHeaderValue(bcc)))
 	}
-	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", enc.Encode("UTF-8", subject)))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", formatSubjectHeader(subject)))
 
 	if inReplyTo != "" {
-		msg.WriteString(fmt.Sprintf("In-Reply-To: %s\r\n", inReplyTo))
+		msg.WriteString(fmt.Sprintf("In-Reply-To: %s\r\n", sanitizeOneLineHeaderValue(inReplyTo)))
 	}
 	if references != "" {
-		msg.WriteString(fmt.Sprintf("References: %s\r\n", references))
+		msg.WriteString(fmt.Sprintf("References: %s\r\n", sanitizeOneLineHeaderValue(references)))
 	}
 
 	msg.WriteString("MIME-Version: 1.0\r\n")

--- a/internal/tools/gmail/helpers_test.go
+++ b/internal/tools/gmail/helpers_test.go
@@ -416,3 +416,30 @@ func TestMessageToDetailWithoutAttachments(t *testing.T) {
 		t.Errorf("expected no attachments, got %d", len(detail.Attachments))
 	}
 }
+
+func TestBuildRawMessageSubjectUTF8RFC2047(t *testing.T) {
+	raw := buildRawMessage("bob@example.com", "café", "Body", "", "", "", "", "")
+	decoded, err := base64.URLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("decoding raw message: %v", err)
+	}
+	msg := string(decoded)
+	if !strings.Contains(msg, "Subject: =?UTF-8?q?caf=C3=A9?=") {
+		t.Errorf("expected RFC 2047 UTF-8 subject, got:\n%s", msg)
+	}
+}
+
+func TestBuildRawMessageSubjectStripsBOM(t *testing.T) {
+	raw := buildRawMessage("bob@example.com", "\ufeffHello", "Body", "", "", "", "", "")
+	decoded, err := base64.URLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("decoding raw message: %v", err)
+	}
+	msg := string(decoded)
+	if !strings.Contains(msg, "Subject: Hello") {
+		t.Errorf("expected BOM stripped from subject, got:\n%s", msg)
+	}
+	if strings.Contains(msg, "Subject: =?UTF-8?q?=EF=BB=BF") {
+		t.Error("subject should not Q-encode a BOM; BOM should be removed")
+	}
+}


### PR DESCRIPTION
## Summary

- **OAuth (Cursor / stdio)**: Duplicate the Google authorization URL to stderr and structured tool output (`auth_url`) when using `start_google_auth`, plus clearer error hints for token refresh and 401s.
- **OAuth callback UI**: Success page shows a 30-second countdown and attempts `window.close()`, with a fallback message if the browser blocks auto-close.
- **Gmail**: RFC 2047 UTF-8 subjects with BOM/control-character sanitization on one-line headers (fixes mangled subject prefixes).

## Verification

- `go test -race ./...`
- `GOOGLE_OAUTH_CLIENT_ID=test GOOGLE_OAUTH_CLIENT_SECRET=test go test -race -tags=integration ./...`

Rebased onto latest `origin/main` (resolved overlaps with signed OAuth state, `ClientInvalidator`, `rb.TextResult()`, and Gmail `Content-Transfer-Encoding: 8bit`).

Made with [Cursor](https://cursor.com)