### PR TITLE
docs(roadmap): SDD-harden epics, sequencing, and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `docs/templates/roadmap_item.md` — SDD-ready epic template (Gherkin ACs, implementation notes, risks).
+- `CHANGELOG.md` — changelog for roadmap hardening and releases.
+
+### Changed
+
+- Roadmap: items use **`XXX-NN-itemname.md`** under `docs/roadmap/`; epics hardened to **`docs/templates/roadmap_item.md`** (Gherkin ACs, scope, implementation notes, component inventory, risks, **Priority**). **`docs/roadmap/README.md`** adds **Seq** (AUTH-01 → SEC-01 → DRV-01 → CON-01), a **POL-01** gate before **PAR-01**, and a Priority column in the items index. **SEC-01** upstream link corrected to PR **#682**. **MCP-01** uses **Horizon: Watchlist** per template.
+- Completed roadmap items are **archived** under `docs/roadmap/archive/` via Product Manager **`/archive-roadmap-item`** (Status **Closed**, README + `archive/README.md` updated).

--- a/docs/roadmap/AUTH-01-pkce-public-client.md
+++ b/docs/roadmap/AUTH-01-pkce-public-client.md
@@ -1,0 +1,149 @@
+# Epic: Auth — PKCE & public (secret-less) client support
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Now |
+| **Priority** | P0 |
+| **Upstream** | [v1.19.0 — SecretLess PKCE](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#677](https://github.com/taylorwilsdon/google_workspace_mcp/pull/677) |
+| **Dependencies** | `docs/auth-and-scopes.md`; `./SEC-01-security-hygiene-upstream.md` may re-audit `internal/auth/credentials.go` after public-client paths land |
+
+## Problem
+
+Today the server requires `GOOGLE_OAUTH_CLIENT_SECRET` at config time (`internal/config/config.go`). Public / native-style OAuth clients use **PKCE** without a confidential secret. That blocks stricter secret hygiene, simpler local onboarding, and alignment with **OAuth 2.1 / MCP authorization** direction in `docs/auth-and-scopes.md`.
+
+## Outcome
+
+Operators can run the server with **only a client ID** (or empty secret where the stack allows), using **PKCE** for the authorization code flow, with **documented** Google Cloud Console redirect URI steps and limitations. Legacy mode (ID + secret) remains supported and tested.
+
+## Scope
+
+### In scope
+
+- Config validation for confidential vs public client modes and PKCE verifier lifecycle.
+- Auth URL generation and code exchange paths in `internal/auth/oauth.go` (and call sites).
+- `start_google_auth` tool (`internal/tools/auth/auth.go`) end-to-end for public mode with local HTTP callback (`internal/auth/callback.go`).
+- Operator docs: `README.md`, `docs/auth-and-scopes.md`, `docs/configuration.md`, `start.sh`, Docker env examples.
+
+### Out of scope
+
+- Full MCP OAuth 2.1 CIMD + OIDC discovery (see `docs/auth-and-scopes.md` v1.1 narrative).
+- Domain-wide delegation (`./ENT-01-domain-wide-delegation-deferred.md`).
+
+## Dependencies
+
+- Google OAuth client type (Web vs Desktop) and redirect URI rules (documented, not guessed).
+- `golang.org/x/oauth2` — PKCE via `oauth2.SetAuthURLParam` and verifier on `Exchange`.
+- Registry: `internal/registry/registry.go` — `start_google_auth` remains hidden when `MCP_ENABLE_OAUTH21` disables legacy auth per existing pattern.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Confidential client still works
+
+```gherkin
+Given GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET are set to non-empty values
+And MCP_ENABLE_OAUTH21 is false
+When the server loads configuration
+Then configuration succeeds without error
+And the OAuth config is treated as confidential (no PKCE requirement for mode selection)
+```
+
+### AC2: Public client mode is explicitly selectable
+
+```gherkin
+Given GOOGLE_OAUTH_CLIENT_ID is set
+And the operator selects public client mode per documented env/flag contract
+When the server loads configuration
+Then configuration succeeds without requiring GOOGLE_OAUTH_CLIENT_SECRET
+And the documented contract states which Google client types and redirect URIs are supported
+```
+
+### AC3: PKCE on authorization and exchange
+
+```gherkin
+Given the server is in public client mode
+When the legacy OAuth flow builds the authorization URL
+Then the URL includes PKCE parameters required by Google for public clients
+When the callback receives an authorization code
+Then the token exchange includes the PKCE code verifier associated with that auth request
+```
+
+### AC4: start_google_auth in public mode
+
+```gherkin
+Given MCP_ENABLE_OAUTH21 is false
+And the server is in public client mode with valid redirect configuration
+When the MCP client invokes start_google_auth for a user email
+Then the tool returns an authorization URL suitable for browser completion
+And after successful browser consent, credentials persist under the existing credentials path semantics
+```
+
+### AC5: OAuth 2.1 mode unchanged
+
+```gherkin
+Given MCP_ENABLE_OAUTH21 is true
+When the server registers tools
+Then start_google_auth is not registered
+And no new code path forces legacy PKCE parameters when OAuth 2.1 is enabled
+```
+
+### AC6: Verification gates
+
+```gherkin
+Given the implementation is complete
+When CI runs golangci-lint and go test -race on ./...
+Then both complete successfully
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Tool: `start_google_auth` — existing name; annotations unchanged unless spec requires new hints.
+- No new tools unless a separate explicitly named `*_pkce` helper is unavoidable (prefer extending existing flow).
+
+### Packages and registration
+
+- `internal/config/config.go` — validate OAuth mode; document env vars in `docs/configuration.md`.
+- `internal/auth/oauth.go` — build auth URL and `Exchange` with conditional PKCE.
+- `internal/auth/callback.go` — ensure callback server compatible with public redirect URIs used in docs.
+- `internal/tools/auth/auth.go` — wire to factory/oauth entrypoints.
+- `internal/registry/registry.go` — preserve OAuth21 filtering for `start_google_auth`.
+
+### Auth and transport
+
+- `cmd/server/main.go` — no regression to stdio / streamable HTTP startup when secret optional.
+- Scopes: `internal/auth/scopes.go` unchanged unless Google public-client rules require different scope strings (unlikely).
+
+### Verification
+
+- `golangci-lint run ./...`, `go test -race ./...`; add `_test.go` for config matrix (public vs confidential) where pure logic allows.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `internal/config/config.go` | Modified |
+| `internal/auth/oauth.go` | Modified |
+| `internal/auth/callback.go` | Modified (if redirect/callback assumptions change) |
+| `internal/tools/auth/auth.go` | Modified |
+| `README.md` | Modified |
+| `docs/auth-and-scopes.md` | Modified |
+| `docs/configuration.md` | Modified |
+| `start.sh` | Modified |
+| `docker-compose.yml` / `Dockerfile` docs | Modified if env contract changes |
+| `.env.example` | Modified |
+
+## Existing infrastructure to reuse
+
+- `internal/auth/credentials.go` — `persistingTokenSource`, directory permissions (0700/0600) patterns; align with `./SEC-01-security-hygiene-upstream.md`.
+- `internal/middleware/errors.go` — messages referencing `start_google_auth`; keep wording accurate for both modes.
+- `internal/integration/registration_test.go` — extend env fixtures for new config branches where feasible.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Google rejects certain redirect URI shapes for public clients | Users cannot complete OAuth | Document one supported console setup; integration-test or script the happy path |
+| Accidental regression disabling OAuth 2.1 path | Enterprise MCP clients break | AC5 + existing `internal/registry/registry.go` tests |
+| PKCE verifier stored incorrectly across concurrent auth attempts | Intermittent exchange failures | Single-flight or per-user verifier map with clear lifecycle in `internal/auth/oauth.go` |

--- a/docs/roadmap/CON-01-contacts-chat-reliability.md
+++ b/docs/roadmap/CON-01-contacts-chat-reliability.md
@@ -1,0 +1,125 @@
+# Epic: Contacts & Chat — reliability and structural parity
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Next |
+| **Priority** | P1 |
+| **Upstream** | Contacts: [v1.19.0 — multi-phone/email, merge modes, batch fix](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#688](https://github.com/taylorwilsdon/google_workspace_mcp/pull/688); Chat: [v1.19.0 — message search stability](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#686](https://github.com/taylorwilsdon/google_workspace_mcp/pull/686) |
+| **Dependencies** | `./SEC-01-security-hygiene-upstream.md`; `docs/auth-and-scopes.md` (People API / Chat scopes); `./POL-01-tool-count-policy.md` if tool split vs parameters changes |
+
+## Problem
+
+Real-world Contacts data uses **multiple phones/emails** and merge semantics; upstream fixed batch and mode gaps. Chat **message search** had stability issues upstream addressed (pagination, empty results, API quirks).
+
+## Outcome
+
+Contacts tools accept and return **multi-value** fields consistent with Google People API semantics; batch operations behave deterministically. Chat search tools do not fail inconsistently on pagination, empty results, or known API edge cases covered upstream.
+
+## Scope
+
+### In scope
+
+- `internal/tools/contacts/` — schemas, handlers, batch paths.
+- `internal/tools/chat/` — search handlers and pagination.
+- Tests and, if useful, a short parity table in PR description or `docs/` appendix.
+
+### Out of scope
+
+- New Chat products beyond the current tool surface unless justified by an explicit parity row and `./POL-01-tool-count-policy.md` decision.
+
+## Dependencies
+
+- Diff upstream tool contracts vs `internal/tools/contacts/`, `internal/tools/chat/`.
+- Scope alignment in `internal/auth/scopes.go` and `docs/auth-and-scopes.md` if new methods require scopes.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Contacts multi-value fields round-trip or validate
+
+```gherkin
+Given contact fixtures or test doubles include multiple emails and phones
+When create or update contacts tools run with multi-value payloads
+Then persisted or returned structures preserve cardinality per People API field semantics
+And invalid combinations produce stable validation errors (no partial silent drops)
+```
+
+### AC2: Contacts batch operations are deterministic
+
+```gherkin
+Given a batch contacts request with merge mode explicitly set per tool contract
+When the batch operation completes
+Then outcomes match documented merge semantics for each input row
+And partial failures report per-item status without corrupting unrelated rows
+```
+
+### AC3: Chat search — empty and single-page results
+
+```gherkin
+Given a Chat space with no matching messages
+When message search runs with valid parameters
+Then the tool returns an empty result set with success semantics
+And does not error solely due to zero results
+```
+
+### AC4: Chat search — pagination stability
+
+```gherkin
+Given search results span multiple pages per Google API
+When the tool aggregates or exposes pagination tokens
+Then repeated calls with the same cursor semantics do not skip or duplicate messages
+And the tool terminates under documented max result or page limits
+```
+
+### AC5: Verification gates
+
+```gherkin
+Given the implementation is complete
+When go test -race ./... runs
+Then it succeeds
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Inventory exact tool names from `internal/tools/contacts/contacts.go` and `internal/tools/chat/chat.go`; preserve names unless `./POL-01-tool-count-policy.md` chooses upstream-aligned splits.
+- Destructive contacts operations keep `DestructiveHint` per `docs/code-patterns.md`.
+
+### Packages and registration
+
+- `internal/tools/contacts/handlers.go`, `helpers.go`, `contacts.go`
+- `internal/tools/chat/handlers.go`, `chat.go`
+- `configs/tool_tiers.yaml` — only if tier membership changes.
+
+### Auth and transport
+
+- No change to `cmd/server/main.go` unless new middleware is required for logging PII — prefer redaction over removal of useful errors.
+
+### Verification
+
+- Unit tests with httptest doubles or golden files; document any manual Chat repro steps in PR if API cannot be mocked.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `internal/tools/contacts/handlers.go` | Modified |
+| `internal/tools/contacts/helpers.go` | Modified |
+| `internal/tools/contacts/contacts.go` | Modified (registration if needed) |
+| `internal/tools/chat/handlers.go` | Modified |
+| `internal/tools/chat/chat.go` | Modified (registration if needed) |
+| `docs/tools-inventory.md` | Modified if contracts change |
+| `docs/auth-and-scopes.md` | Modified if scopes change |
+
+## Existing infrastructure to reuse
+
+- `internal/middleware/errors.go` — Google API error shaping for People and Chat.
+- `internal/middleware/retry.go` — 429 handling for search-heavy calls.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| People API batch limits differ from assumptions | Intermittent 400s | Match Google quotas in code; document limits in tool descriptions |
+| Chat API behavior changes without notice | Flaky integration | Pin test doubles; narrow client surface |

--- a/docs/roadmap/DOC-01-docs-quality-output.md
+++ b/docs/roadmap/DOC-01-docs-quality-output.md
@@ -1,0 +1,119 @@
+# Epic: Docs — quality of markdown / tables / batch updates
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Then |
+| **Priority** | P2 |
+| **Upstream** | Table batch operations [#656](https://github.com/taylorwilsdon/google_workspace_mcp/pull/656); `create_table_with_data` fix [#653](https://github.com/taylorwilsdon/google_workspace_mcp/pull/653); smart chips / paragraph rendering [#649](https://github.com/taylorwilsdon/google_workspace_mcp/pull/649); sophisticated Docs creation [#628](https://github.com/taylorwilsdon/google_workspace_mcp/pull/628) |
+| **Dependencies** | `./POL-01-tool-count-policy.md`; `internal/tools/docs/`; `./SEC-01-security-hygiene-upstream.md` (large-doc memory bounds) |
+
+## Problem
+
+Agents judge quality by **readable structure** (markdown, tables, smart chips) when reading or round-tripping Docs — not only API success. Upstream invested heavily in fidelity and batch table operations.
+
+## Outcome
+
+Docs read paths produce **more faithful** structured text for agents; table create/update batch tools **fail loudly** or succeed atomically on covered cases (no silent empty tables). Documented limits prevent unbounded memory use on large documents.
+
+## Scope
+
+### In scope
+
+- `internal/tools/docs/` read and write paths affecting markdown/table fidelity.
+- Fixtures or integration-tagged tests for table create/populate.
+- Release-note style summary for users migrating from Python MCP.
+
+### Out of scope
+
+- Full WYSIWYG parity with the Google Docs web UI.
+
+## Dependencies
+
+- `docs/code-patterns.md` for structured vs text responses.
+- Google Docs API batch limits — document in tool descriptions.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Table create or populate — success path
+
+```gherkin
+Given a representative Docs table fixture or test document id
+When create_table_with_data or equivalent batch table tool runs with valid parameters
+Then the document contains the expected rows and columns
+And the tool response confirms success with structured summary
+```
+
+### AC2: Table batch — failure is explicit
+
+```gherkin
+Given parameters that violate Docs API or documented size limits
+When the batch table tool runs
+Then the tool returns a structured error without partial silent success
+And the document is not left in an undeclared inconsistent state when atomicity is promised in docs
+```
+
+### AC3: Read path markdown fidelity
+
+```gherkin
+Given a document fixture with headings lists and a simple table
+When the read Doc content tool runs
+Then the returned markdown preserves logical structure per golden file expectations
+```
+
+### AC4: Large document bounds
+
+```gherkin
+Given a document at the documented size limit
+When the read path executes
+Then peak memory stays within documented bounds or the tool errors with a clear limit message
+```
+
+### AC5: Verification gates
+
+```gherkin
+Given the implementation merges
+When golangci-lint run ./... and go test -race ./... execute
+Then both succeed
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Exact tool names from `internal/tools/docs/docs.go`; extend parameters vs new tools per `./POL-01-tool-count-policy.md`.
+
+### Packages and registration
+
+- `internal/tools/docs/handlers.go`, helpers, `docs.go`
+- Shared utilities only if duplication is proven — prefer small focused helpers under `internal/pkg/`.
+
+### Auth and transport
+
+- Scopes in `internal/auth/scopes.go` — Docs read/write already present; extend only if new methods require additional scopes.
+
+### Verification
+
+- Golden markdown files under `internal/tools/docs/testdata/` or integration tests with `-tags=integration`.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `internal/tools/docs/handlers.go` | Modified |
+| `internal/tools/docs/docs.go` | Modified |
+| `internal/pkg/*` | Modified only if shared helper justified |
+| `docs/tools-inventory.md` | Modified |
+| `CHANGELOG.md` | Modified under [Unreleased] for user-visible behavior |
+
+## Existing infrastructure to reuse
+
+- `internal/pkg/response/builder.go` — dual output.
+- Comment tools under `internal/tools/comments/` if table operations share list/update patterns.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Docs API batch partial failures | Corrupt user documents | Map to batch response semantics; add tests for failure injection |
+| Markdown export diverges from Google rendering | Agent confusion | Version golden files when API output shifts |

--- a/docs/roadmap/DRV-01-drive-file-content-fidelity.md
+++ b/docs/roadmap/DRV-01-drive-file-content-fidelity.md
@@ -1,0 +1,124 @@
+# Epic: Drive — file content fidelity (PDF, binaries, attachments)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Next |
+| **Priority** | P1 |
+| **Upstream** | [v1.19.0 — PDF text extraction & image passthrough for `get_drive_file_content`](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#659](https://github.com/taylorwilsdon/google_workspace_mcp/pull/659); [v1.19.0 — inaccessible directory warning](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#691](https://github.com/taylorwilsdon/google_workspace_mcp/pull/691) |
+| **Dependencies** | `./SEC-01-security-hygiene-upstream.md` (size/path bounds); `docs/security.md`; `./POL-01-tool-count-policy.md` only if new tools are required instead of extending `get_drive_file_content` |
+
+## Problem
+
+Agents expect `get_drive_file_content` to behave predictably on **PDFs** and **non-text binaries** (clear errors, extracted text where feasible, or structured passthrough). Gaps vs upstream create “works in Python MCP” friction without renaming tools.
+
+## Outcome
+
+Documented, bounded behavior for PDF and common binary types: **text extraction** where safe, **explicit** base64/size-cap policy or export path where not, and **warnings** when Drive returns items the principal cannot read (shortcuts / shared drive edge cases) where the API exposes detectable signals without excessive false positives.
+
+## Scope
+
+### In scope
+
+- `get_drive_file_content` behavior, helpers, and tool description text.
+- Size limits, timeouts, and security alignment per `docs/security.md`.
+- Tests with fixtures (small PDF, plain text, unsupported binary).
+
+### Out of scope
+
+- Replacing `export_doc_to_pdf` or other export tools — this epic is **Drive file read** fidelity only.
+
+## Dependencies
+
+- `internal/tools/drive/handlers.go`, `internal/tools/drive/helpers.go`, `internal/pkg/office/extract.go` as applicable.
+- `docs/tools-inventory.md` if parameters or semantics change.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Plain text and native Google formats
+
+```gherkin
+Given a small plain-text Drive file or supported native export path
+When get_drive_file_content is invoked with valid file id and user context
+Then the tool returns deterministic text or structured content per docs/tools-inventory.md
+And response size stays within documented limits
+```
+
+### AC2: PDF — success or explicit failure
+
+```gherkin
+Given a PDF fixture representative of text-based PDFs
+When get_drive_file_content is invoked
+Then either extractable text is returned
+Or the tool returns a structured error with a stable reason code string documented for agents
+And the tool does not silently return empty content when extraction failed
+```
+
+### AC3: Unsupported binary
+
+```gherkin
+Given a non-text binary type outside the supported set
+When get_drive_file_content is invoked
+Then the tool refuses or returns a documented bounded representation (e.g. base64 chunk policy)
+And memory usage stays bounded for a large file per documented cap
+```
+
+### AC4: Inaccessible or partial-access items
+
+```gherkin
+Given Drive returns conditions equivalent to upstream’s “inaccessible directory” class of issues where detectable
+When get_drive_file_content is invoked
+Then the tool surfaces a user-visible warning or error consistent with docs/tools-inventory.md
+And does not claim success with empty misleading content
+```
+
+### AC5: Verification gates
+
+```gherkin
+Given the implementation is complete
+When golangci-lint run ./... and go test -race ./... execute
+Then both succeed
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Primary tool: `get_drive_file_content` — preserve `snake_case` name; extend parameters only if `./POL-01-tool-count-policy.md` allows (prefer optional fields on existing tool).
+- Annotations: preserve `ReadOnlyHint` / size-related hints per `docs/code-patterns.md`.
+
+### Packages and registration
+
+- `internal/tools/drive/handlers.go`, `internal/tools/drive/helpers.go`
+- `internal/pkg/office/extract.go` — reuse before adding new PDF dependency; justify new deps in `go.mod` in PR.
+
+### Auth and transport
+
+- No OAuth scope expansion unless Google export APIs require it — document in `docs/auth-and-scopes.md` if changed.
+
+### Verification
+
+- Unit tests with committed small fixtures under `internal/tools/drive/` (or testdata).
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `internal/tools/drive/handlers.go` | Modified |
+| `internal/tools/drive/helpers.go` | Modified |
+| `internal/pkg/office/extract.go` | Modified (if reuse extended) |
+| `go.mod` / `go.sum` | Modified only if justified |
+| `docs/tools-inventory.md` | Modified |
+| `docs/security.md` | Modified if new limits documented |
+
+## Existing infrastructure to reuse
+
+- `internal/pkg/response/builder.go` — dual text + structured output per `docs/code-patterns.md`.
+- `internal/middleware/retry.go` — 429 backoff for Drive API reads.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| New PDF parser dependency increases supply-chain surface | Security review overhead | Prefer stdlib + existing `internal/pkg/office` patterns; pin minimal version |
+| False-positive “inaccessible” warnings | User trust drops | Gate warnings on API signals documented in PR; add regression tests |

--- a/docs/roadmap/ENT-01-domain-wide-delegation-deferred.md
+++ b/docs/roadmap/ENT-01-domain-wide-delegation-deferred.md
@@ -1,0 +1,91 @@
+# Deferred: Enterprise — domain-wide delegation (DWD) / service accounts
+
+| Field | Value |
+|-------|--------|
+| **Status** | Deferred |
+| **Horizon** | Deferred |
+| **Priority** | P3 |
+| **Upstream** | [v1.18.0 — DWD / service account mode](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.18.0), [#665](https://github.com/taylorwilsdon/google_workspace_mcp/pull/665) — upstream **warns against casual use** |
+| **Dependencies** | Conflicts with interactive OAuth assumptions documented in `./AUTH-01-pkce-public-client.md` and `docs/auth-and-scopes.md`; requires enterprise legal/security path |
+
+## Problem
+
+Domain-wide delegation is powerful and **dangerous** if misconfigured. This project emphasizes production safety. DWD also **conflicts** with interactive OAuth and single-user assumptions unless very carefully scoped.
+
+## Outcome
+
+While deferred: no implementation. If un-deferred: documented, **off-by-default** capability with hard startup validation, impersonation audit story, and explicit incompatibility matrix vs OAuth 2.0 / OAuth 2.1 modes.
+
+## Scope
+
+### In scope (only when un-deferred)
+
+- Threat model, admin controls, key storage, rotation, audit logging.
+- Startup validation matrix vs `MCP_ENABLE_OAUTH21` and legacy OAuth.
+
+### Out of scope (until gating criteria met)
+
+- Any DWD code paths, flags, or tools in the default build.
+
+## Dependencies
+
+- Enterprise customer demand and administrator-owned Google Workspace controls.
+- Legal / security review sign-off.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: While deferred — no DWD surface
+
+```gherkin
+Given the epic status is Deferred
+When a reviewer searches the codebase for domain-wide delegation or service-account impersonation flags
+Then no supported operator path enables DWD without an explicit future epic and ADR
+```
+
+### AC2: When un-deferred — gating documented first
+
+```gherkin
+Given stakeholders approve un-deferring ENT-01
+When planning completes
+Then docs include gating criteria met threat model admin controls and incompatibility matrix
+And a new implementation epic references this file and supersedes Deferred status
+```
+
+### AC3: When un-deferred — startup validation
+
+```gherkin
+Given DWD mode is implemented behind an explicit env flag
+When forbidden combinations are configured
+Then the server fails fast with an actionable error before registering tools
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- N/A while deferred; future work must annotate high-risk tools per `docs/security.md`.
+
+### Packages and registration
+
+- Would touch `internal/auth/*`, `internal/config/*`, `cmd/server/main.go` — **no changes** until un-deferred.
+
+### Verification
+
+- N/A while deferred.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| — | No changes while Deferred |
+
+## Existing infrastructure to reuse
+
+- N/A until un-deferred; future reuse of `internal/config/config.go` validation patterns from `./AUTH-01-pkce-public-client.md`.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Casual DWD enablement | Workspace-wide data exfiltration | Keep deferred; require ADR + security review before code |
+| Pressure to “match upstream” quickly | Shipping foot-guns | README positions ENT-01 as explicit opt-in only |

--- a/docs/roadmap/MCP-01-client-compat-shims.md
+++ b/docs/roadmap/MCP-01-client-compat-shims.md
@@ -1,0 +1,94 @@
+# Watchlist: MCP client compatibility shims
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Watchlist |
+| **Priority** | P2 |
+| **Upstream** | [v1.15.1 — Claude Cowork / Desktop JSON workarounds](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.15.1); [v1.19.0 — “patch shims”](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0); DXT / stdio fixes [e.g. #626](https://github.com/taylorwilsdon/google_workspace_mcp/pull/626) |
+| **Dependencies** | MCP spec (`github.com/modelcontextprotocol/go-sdk`); `cmd/server/main.go` transports; optional `.github/ISSUE_TEMPLATE/` for repro fields |
+
+## Problem
+
+Some MCP clients send **invalid JSON** or otherwise violate the spec for tool arguments. Upstream added **temporary shims** for specific clients.
+
+## Outcome
+
+**No server-side shim** until: a **named client + version**, minimal repro payload, MCP spec reference, narrow scope, and documented **removal condition**. Until then this item remains watchlist-only (no scheduled engineering).
+
+## Scope
+
+### In scope
+
+- Issue template or docs note for capturing client version + repro when shims are proposed.
+- Future focused epic per client if justified.
+
+### Out of scope
+
+- Broad spec violations “for compatibility” without named client and removal plan.
+- Duplicating upstream shims preemptively.
+
+## Dependencies
+
+- `cmd/server/main.go` — stdio vs streamable HTTP entrypoints.
+- `.github/ISSUE_TEMPLATE/` — optional field for MCP client name and version.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Default — no undocumented shims
+
+```gherkin
+Given MCP-01 remains on the watchlist
+When reviewers inspect argument parsing paths
+Then no client-specific shim exists without a linked issue naming client version and removal condition
+```
+
+### AC2: Issue intake — client identity
+
+```gherkin
+Given a contributor files a client-compat bug
+When they use the bug template updated for this epic
+Then the issue includes MCP client name version transport stdio or HTTP and minimal JSON repro
+```
+
+### AC3: If a shim ships — documentation and removal
+
+```gherkin
+Given a shim is approved and merged
+When a reader opens the shim source
+Then a comment cites MCP spec section client versions covered and the removal condition
+And docs mention the temporary nature under docs/ or CHANGELOG
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Shims must not weaken validation for conforming clients.
+
+### Packages and registration
+
+- Likely `cmd/server/main.go`, `internal/middleware/*`, or SDK wiring — only when AC3 triggers.
+
+### Verification
+
+- Regression tests that conforming payloads are unchanged; shim covered by targeted test with fixture from repro.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `.github/ISSUE_TEMPLATE/bug_report.yml` | Modified (optional fields) |
+| `cmd/server/main.go` | Modified only if shim approved |
+| `internal/middleware/*` | Modified only if shim approved |
+
+## Existing infrastructure to reuse
+
+- `internal/middleware/errors.go` — prefer correct spec errors over silent fixes when rejecting shims.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Shim sprawl | unmaintainable server | Watchlist principle — one epic per client |
+| Shims hide client bugs forever | spec ecosystem degrades | removal condition in code comment + issue |

--- a/docs/roadmap/PAR-01-calendar-sheets-gmail-parity.md
+++ b/docs/roadmap/PAR-01-calendar-sheets-gmail-parity.md
@@ -1,0 +1,123 @@
+# Epic: Calendar, Sheets, Gmail — upstream feature drift
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Then |
+| **Priority** | P1 |
+| **Upstream** | Examples: `resize_sheet_dimensions` [v1.18.0 #662](https://github.com/taylorwilsdon/google_workspace_mcp/pull/662); `manage_focus_time`, `rsvp_event`, OOO, `create_calendar` + scope fixes ([releases](https://github.com/taylorwilsdon/google_workspace_mcp/releases)); Gmail `body_format` [e.g. #571](https://github.com/taylorwilsdon/google_workspace_mcp/pull/571); drafts overhaul [#631](https://github.com/taylorwilsdon/google_workspace_mcp/pull/631); filters + list headers [v1.15.1](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.15.1) |
+| **Dependencies** | **`./POL-01-tool-count-policy.md` must be decided first**; `docs/auth-and-scopes.md`; `docs/tools-inventory.md`; `configs/tool_tiers.yaml` |
+
+## Problem
+
+Upstream has added **tools and parameters** after baseline `docs/tools-inventory.md` (136 tools). Agents migrating from the Python server expect behaviors (RSVP, focus time, sheet dimension resize, raw HTML mail bodies, richer drafts).
+
+## Outcome
+
+A **prioritized backlog** (P0/P1/P2) of upstream deltas with one of: (a) implement in Go, (b) document intentional omission, (c) extend existing tools via optional parameters per `./POL-01-tool-count-policy.md`. Execution splits into small PRs per service.
+
+## Scope
+
+### In scope
+
+- Parity analysis tables and phased implementation PRs for Calendar, Sheets, and Gmail.
+- Registry and tier updates when tools change.
+- Documentation updates for intentional gaps.
+
+### Out of scope
+
+- Rewriting entire Gmail or Calendar surfaces in one PR.
+- Drive/Docs/Chat coverage (handled by sibling epics).
+
+## Dependencies
+
+- `./POL-01-tool-count-policy.md` — blocks implementation choices.
+- `internal/tools/calendar/`, `internal/tools/sheets/`, `internal/tools/gmail/`.
+- `internal/registry/registry.go` name validation (SEP-986).
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Policy alignment before merge-heavy work
+
+```gherkin
+Given POL-01 records a single chosen option A B or C with owner sign-off
+When PAR-01 implementation PRs are opened
+Then each PR states how new upstream behavior maps to that policy
+```
+
+### AC2: Backlog artifact exists
+
+```gherkin
+Given PAR-01 is in progress or complete for a slice
+When a reviewer opens the linked backlog table in-repo or in a referenced PR
+Then each upstream delta row includes priority P0 P1 P2 mapping to our tool or omission rationale and T-shirt effort
+```
+
+### AC3: P0 handling
+
+```gherkin
+Given a backlog row is marked P0
+When the epic slice closes
+Then that row is implemented in Go or explicitly deferred with reason and follow-up issue link
+```
+
+### AC4: Inventory and tiers stay truthful
+
+```gherkin
+Given tools or parameters change
+When the slice merges
+Then docs/tools-inventory.md and configs/tool_tiers.yaml reflect the new surface
+```
+
+### AC5: Verification gates
+
+```gherkin
+Given code changes merge
+When golangci-lint run ./... and go test -race ./... execute
+Then both succeed
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Follow `docs/code-patterns.md` for dual output, hints (`ReadOnlyHint`, `DestructiveHint`, `IdempotentHint`, `OpenWorldHint`).
+- Exact `snake_case` names validated in `internal/registry/registry.go`.
+
+### Packages and registration
+
+- `internal/tools/calendar/*.go`, `internal/tools/sheets/*.go`, `internal/tools/gmail/*.go`
+- `internal/services/factory.go` — new Google API clients only if scopes/services expand.
+
+### Auth and transport
+
+- `internal/auth/scopes.go` — extend minimal scope sets; document in `docs/auth-and-scopes.md`.
+
+### Verification
+
+- Handler `_test.go` per changed package; integration tests where `-tags=integration` already applies.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `internal/tools/calendar/*` | Modified |
+| `internal/tools/sheets/*` | Modified |
+| `internal/tools/gmail/*` | Modified |
+| `internal/registry/registry.go` | Modified if registration rules change |
+| `configs/tool_tiers.yaml` | Modified |
+| `docs/tools-inventory.md` | Modified |
+| `docs/auth-and-scopes.md` | Modified |
+| `docs/implementation-plan.md` | Modified if Phase 4 exit criteria change |
+
+## Existing infrastructure to reuse
+
+- `internal/tools/comments/` pattern for shared comment-related flows where Calendar/Docs overlap.
+- `internal/pkg/htmlutil` / Gmail helpers for body format handling.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| POL-01 slips while engineers start PAR work | Rework from wrong tool-split strategy | README sequencing — treat POL-01 as gate |
+| Scope creep on Gmail drafts | Large PRs | Cap each merge to one upstream theme |

--- a/docs/roadmap/POL-01-tool-count-policy.md
+++ b/docs/roadmap/POL-01-tool-count-policy.md
@@ -1,0 +1,115 @@
+# Decision: Tool count vs upstream parity
+
+| Field | Value |
+|-------|--------|
+| **Status** | **Decision needed** |
+| **Horizon** | Policy |
+| **Priority** | P0 |
+| **Upstream** | New tools such as `resize_sheet_dimensions`, `create_calendar`, `rsvp_event`, `manage_focus_time`, etc. ([releases](https://github.com/taylorwilsdon/google_workspace_mcp/releases)) |
+| **Dependencies** | Blocks `./PAR-01-calendar-sheets-gmail-parity.md` and constrains `./DRV-01-drive-file-content-fidelity.md`, `./CON-01-contacts-chat-reliability.md`, `./DOC-01-docs-quality-output.md` when tool splits vs parameters are ambiguous |
+
+## Problem
+
+Without an explicit policy, parity work oscillates between **strict tool-count stability** and **upstream-shaped tool names**, creating rework in `internal/registry/registry.go`, `docs/tools-inventory.md`, and MCP client integrations.
+
+## Outcome
+
+One **recorded decision** (option A, B, or C below) with sign-off in a PR, reflected in `docs/tools-inventory.md` and, if applicable, `docs/implementation-plan.md` Phase 4 exit criteria. Engineers can implement PAR/DOC/CON/DRV changes without reopening the debate each sprint.
+
+## Scope
+
+### In scope
+
+- Choose A, B, or C and document consequences for registry validation and docs.
+- Update header/policy statements in `docs/tools-inventory.md`.
+
+### Out of scope
+
+- Implementing PAR-01 itself (this epic is **decision + doc gates** only).
+
+## Dependencies
+
+- Current inventory: `docs/tools-inventory.md` (136 tools baseline).
+- Registry: `internal/registry/registry.go` (SEP-986 naming).
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Decision is singular and stored
+
+```gherkin
+Given stakeholders review options A B and C
+When the decision PR merges
+Then this file’s metadata records exactly one chosen option by letter
+And the choice is restated in docs/tools-inventory.md header or policy subsection
+```
+
+### AC2: Implementation plan alignment
+
+```gherkin
+Given the chosen option changes Phase 4 assumptions about fixed tool count
+When the decision PR merges
+Then docs/implementation-plan.md Phase 4 exit criteria are updated to match
+Or explicitly states tool count is no longer fixed at 136 with the new rule
+```
+
+### AC3: Downstream epics can cite the policy
+
+```gherkin
+Given PAR-01 or other parity epics are opened after the decision
+When reviewers read the epic or PR description
+Then each references POL-01 option letter and does not contradict it
+```
+
+### AC4: No code requirement for closure
+
+```gherkin
+Given POL-01 is a policy epic
+When only documentation files change
+Then golangci-lint and go test may still be required by repo CI for the PR
+And the epic can close without production code changes
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Decision drives whether new upstream tools become new `snake_case` registrations vs optional JSON on existing tools.
+
+### Packages and registration
+
+- No code changes required to **close** POL-01; subsequent epics modify `internal/tools/*` and `internal/registry/registry.go`.
+
+### Verification
+
+- Doc-only PR: `markdown` / human review; follow normal CI if any touched files trigger builds.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `docs/roadmap/POL-01-tool-count-policy.md` | Modified |
+| `docs/tools-inventory.md` | Modified |
+| `docs/implementation-plan.md` | Modified (if exit criteria change) |
+
+## Existing infrastructure to reuse
+
+- N/A — policy artifact.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Hybrid option C without guardrails | endless judgment calls | Add a short “when to add a new tool” checklist in docs/tools-inventory.md |
+| Decision delayed | PAR-01 blocked | Time-box decision; default to documented interim rule |
+
+## Options (reference)
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **A — Strict 136** | Stable inventory, simpler docs, predictable MCP clients | Awkward when upstream’s tool split is clearer; richer single-tool schemas |
+| **B — Track upstream** | Easier mental migration from Python MCP; clearer tool names | More registry/tier work; docs chase releases |
+| **C — Hybrid** | Pragmatic balance | Requires ongoing judgment calls |
+
+### Recommendation (PM)
+
+Default to **C — Hybrid** unless the team commits to full parity automation: add tools when they **reduce ambiguity** or **match Google API resource boundaries**; otherwise extend existing tools with optional JSON fields.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,75 @@
+# Roadmap
+
+Outcome-oriented work derived from **repo goals** (`docs/implementation-plan.md`, `docs/tools-inventory.md`) and drift vs the upstream **[google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp)** project (releases and community PRs). This folder is the **planning source**; implementation detail stays in `docs/code-patterns.md`, `docs/auth-and-scopes.md`, and service-specific docs.
+
+**This `README.md` is the roadmap overview** — keep the **horizon summary**, **sequencing**, and **items index** current whenever you add, rename, split, merge, or change status/priority of roadmap files.
+
+## Roadmap item filenames
+
+Each item is a single markdown file in this directory, named:
+
+`XXX-NN-itemname.md`
+
+| Part | Meaning |
+|------|---------|
+| **`XXX`** | Short **topic** tag (3 letters, uppercase). Examples: `AUTH` (OAuth/auth flows), `SEC` (security hygiene), `DRV` (Drive), `DOC` (Docs output), `POL` (policy decisions), `PAR` (multi-service parity), `CON` (Contacts/Chat), `ENT` (enterprise), `MCP` (MCP protocol/client). |
+| **`NN`** | Two-digit sequence **per topic** (`01`, `02`, …). Renumber only when splitting/merging items; otherwise use the next free number for that topic. |
+| **`itemname`** | Lowercase **kebab-case** slug (no spaces). |
+
+Examples: `AUTH-01-pkce-public-client.md`, `SEC-09-oauth-serverless-version.md`.
+
+Cross-link other items with the **filename** (e.g. `` `POL-01-tool-count-policy.md` ``), not free-text-only references.
+
+## How to use these items
+
+Each file is one **epic** (shippable theme). Prefer small PRs that close a subset of **Gherkin acceptance criteria** in the item. Link PRs to the roadmap **ID** (e.g. `AUTH-01`) and filename in the PR description when relevant.
+
+**Hardening for development:** Use the Product Manager **`/harden`** slash command in Cursor (see `.cursor/commands/product-manager/harden.md` locally) with the item path. Canonical structure and AC format live in **`docs/templates/roadmap_item.md`**. Hardening updates should add a line under **`CHANGELOG.md`** → `[Unreleased]`.
+
+**Archiving completed work:** Use **`/archive-roadmap-item`** (see `.cursor/commands/product-manager/archive-roadmap-item.md` locally). That sets **Status** to **Closed**, moves the file to **`docs/roadmap/archive/`**, removes it from the **horizon** and **items index** tables below, and appends a row to the **Archived items** table in **`docs/roadmap/archive/README.md`**.
+
+## Upstream reference
+
+- Repository: [taylorwilsdon/google_workspace_mcp](https://github.com/taylorwilsdon/google_workspace_mcp)
+- Recent release themes (PKCE, Drive PDF/attachments, Contacts, Chat stability, security): see [releases](https://github.com/taylorwilsdon/google_workspace_mcp/releases).
+
+## Horizon summary
+
+| Horizon | Seq | ID | Priority | Epic | One-line outcome |
+|---------|-----|-----|----------|------|------------------|
+| **Now** | 1 | AUTH-01 | P0 | [PKCE & public client](./AUTH-01-pkce-public-client.md) | Optional client secret; PKCE where Google allows; docs + console steps |
+| **Next** | 1 | SEC-01 | P0 | [Security hygiene (upstream-informed)](./SEC-01-security-hygiene-upstream.md) | Credential/path/input invariants audited before expanding read surfaces |
+| **Next** | 2 | DRV-01 | P1 | [Drive: content fidelity](./DRV-01-drive-file-content-fidelity.md) | `get_drive_file_content` matches PDF/binary expectations with bounded behavior |
+| **Next** | 3 | CON-01 | P1 | [Contacts & Chat reliability](./CON-01-contacts-chat-reliability.md) | Multi-value contacts + deterministic Chat search vs upstream |
+| **Policy** | — | POL-01 | P0 | [Tool count vs upstream](./POL-01-tool-count-policy.md) | **Gate before PAR-01 merges:** choose A/B/C; update inventory + plan |
+| **Then** | 1 | PAR-01 | P1 | [Calendar, Sheets, Gmail parity](./PAR-01-calendar-sheets-gmail-parity.md) | Close feature drift per POL-01 decision |
+| **Then** | 2 | DOC-01 | P2 | [Docs: quality of output](./DOC-01-docs-quality-output.md) | Markdown/table fidelity for agent-consumed Doc content |
+| **Deferred** | — | ENT-01 | P3 | [Enterprise: DWD / service accounts](./ENT-01-domain-wide-delegation-deferred.md) | Only if explicitly required; high risk |
+| **Watchlist** | — | MCP-01 | P2 | [MCP client compat shims](./MCP-01-client-compat-shims.md) | Shims only with named client + removal condition |
+
+**Seq** is the recommended merge order within a horizon (lower first). `—` means not sequenced against siblings (single item or non-executable).
+
+### Sequencing rules
+
+1. **AUTH-01** ships first — everything depends on auth/config correctness.
+2. **SEC-01** immediately follows AUTH-01 — credential and path invariants before expanding high-risk read paths (**DRV-01**) and multi-value APIs (**CON-01**).
+3. **POL-01** must record **one** option (A/B/C) before **PAR-01** implementation PRs merge; backlog research for PAR-01 may run in parallel, but merges that add or split tools must cite the signed policy (**PAR-01** AC1).
+4. **DOC-01** can proceed independently of PAR-01 after **POL-01** if tool-split choices are already satisfied; if in doubt, sequence DOC-01 after PAR-01’s first merged slice.
+
+## Items index
+
+| ID | Priority | File | Status |
+|----|----------|------|--------|
+| AUTH-01 | P0 | [AUTH-01-pkce-public-client.md](./AUTH-01-pkce-public-client.md) | Proposed |
+| SEC-01 | P0 | [SEC-01-security-hygiene-upstream.md](./SEC-01-security-hygiene-upstream.md) | Proposed |
+| DRV-01 | P1 | [DRV-01-drive-file-content-fidelity.md](./DRV-01-drive-file-content-fidelity.md) | Proposed |
+| CON-01 | P1 | [CON-01-contacts-chat-reliability.md](./CON-01-contacts-chat-reliability.md) | Proposed |
+| POL-01 | P0 | [POL-01-tool-count-policy.md](./POL-01-tool-count-policy.md) | **Decision needed** |
+| PAR-01 | P1 | [PAR-01-calendar-sheets-gmail-parity.md](./PAR-01-calendar-sheets-gmail-parity.md) | Proposed |
+| DOC-01 | P2 | [DOC-01-docs-quality-output.md](./DOC-01-docs-quality-output.md) | Proposed |
+| ENT-01 | P3 | [ENT-01-domain-wide-delegation-deferred.md](./ENT-01-domain-wide-delegation-deferred.md) | Deferred |
+| MCP-01 | P2 | [MCP-01-client-compat-shims.md](./MCP-01-client-compat-shims.md) | Watchlist |
+
+## Archived items
+
+Completed items are listed in **[`archive/README.md`](./archive/README.md)** (table of **Closed** items with links under `docs/roadmap/archive/`). Do not keep closed items in the horizon or items index above.

--- a/docs/roadmap/SEC-01-security-hygiene-upstream.md
+++ b/docs/roadmap/SEC-01-security-hygiene-upstream.md
@@ -1,0 +1,122 @@
+# Epic: Security hygiene (upstream-informed audit)
+
+| Field | Value |
+|-------|--------|
+| **Status** | Proposed |
+| **Horizon** | Next |
+| **Priority** | P0 |
+| **Upstream** | [v1.19.0 — security / patch themes](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0); credential permissions + path handling [#657](https://github.com/taylorwilsdon/google_workspace_mcp/pull/657); related hardening [#682](https://github.com/taylorwilsdon/google_workspace_mcp/pull/682) |
+| **Dependencies** | `./AUTH-01-pkce-public-client.md` (optional secret) may change credential files layout — coordinate ordering or re-audit after AUTH-01 merges; `docs/security.md` |
+
+## Problem
+
+Upstream fixed classes of issues (credential file permissions, path traversal / sanitization, related hardening). The Go server must enforce the same **invariants** without copying Python line-by-line.
+
+## Outcome
+
+A completed **audit checklist** (checked items in `docs/security.md` or a single linked audit file under `docs/roadmap/`) covering credential paths, file permissions, user-influenced paths, log redaction, and input bounds on high-risk tools. Every **High** finding is fixed or tracked with owner and timeline.
+
+## Scope
+
+### In scope
+
+- Read-only engineering audit with concrete file/path references.
+- Checklist artifacts and fixes for issues rated High or Medium.
+- Alignment with `docs/implementation-plan.md` Phase 1 credential expectations (0700/0600).
+
+### Out of scope
+
+- Full third-party penetration test.
+- New product features disguised as security work.
+
+## Dependencies
+
+- `docs/security.md`, `internal/auth/credentials.go`, tools accepting paths or writing local data.
+- Optional traceability: map findings to upstream PRs above.
+
+## Acceptance criteria (Gherkin)
+
+### AC1: Audit checklist exists and is objective
+
+```gherkin
+Given the epic is complete
+When a reviewer opens docs/security.md (or the linked audit subsection)
+Then a checklist exists with pass/fail rows for credential paths, permissions, path sanitization, log redaction, and high-risk tool input bounds
+And each row references at least one repo path or tool name to verify
+```
+
+### AC2: Credential directory and token file permissions
+
+```gherkin
+Given a fresh credentials directory is created by the server
+When token material is written to disk
+Then directory and file permissions match the values documented in docs/security.md (0700/0600 as applicable)
+And no regression introduces world-readable token files
+```
+
+### AC3: High-severity gaps are closed or tracked
+
+```gherkin
+Given the audit identifies a High severity issue
+When the epic closes
+Then the issue is fixed in code with tests or documentation
+Or a GitHub issue exists with severity, mitigation, and target date
+```
+
+### AC4: Path-influenced tools
+
+```gherkin
+Given a tool accepts a user-controlled file path or document identifier that maps to local or API resources
+When inputs include traversal sequences or out-of-range values
+Then the server rejects or normalizes them per documented rules without leaking internal paths in tool output
+```
+
+### AC5: Verification gates
+
+```gherkin
+Given changes land on main
+When CI runs golangci-lint and go test -race on ./...
+Then both complete successfully
+```
+
+## Implementation notes
+
+### MCP tool surface
+
+- Focus on tools that accept paths, IDs with filesystem semantics, or export large payloads — inventory from `internal/tools/` (Drive, Docs, local-adjacent helpers).
+
+### Packages and registration
+
+- `internal/auth/credentials.go` — chmod, mkdir, symlink/hardlink considerations if any.
+- `internal/config/config.go` — paths from env vars.
+- `cmd/server/main.go` — logging configuration; ensure secrets not logged.
+
+### Auth and transport
+
+- Callback server `internal/auth/callback.go` — bind address, CSRF/state if applicable.
+
+### Verification
+
+- Add or extend `_test.go` for permission bits where OS allows; document macOS vs Linux differences in checklist if needed.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `docs/security.md` | Modified (checklist + outcomes) |
+| `internal/auth/credentials.go` | Modified (if gaps) |
+| `internal/auth/callback.go` | Modified (if gaps) |
+| Target tool handlers under `internal/tools/**` | Modified as findings dictate |
+| `docs/roadmap/audit-YYYY-MM.md` | New (optional; only if team prefers append-only audit file) |
+
+## Existing infrastructure to reuse
+
+- `internal/middleware/logging.go` — redaction patterns if present.
+- `internal/middleware/errors.go` — ensure error messages do not echo raw tokens.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| AUTH-01 changes credential storage concurrently | Duplicate or conflicting audits | Run SEC checklist after AUTH-01 or explicitly re-run delta audit |
+| Platform-specific permission tests flaky in CI | False green | Gate strict chmod tests behind build tags or document manual verification steps |

--- a/docs/roadmap/archive/README.md
+++ b/docs/roadmap/archive/README.md
@@ -1,0 +1,11 @@
+# Roadmap archive
+
+Completed (or explicitly **Closed**) roadmap items live here as **`XXX-NN-itemname.md`**. Each file keeps the same naming convention as active items; **Status** in the metadata table should be **`Closed`**.
+
+Active work and the canonical overview stay in **`../README.md`**.
+
+## Archived items
+
+| ID | File | Closed (approx.) | Note |
+|----|------|------------------|------|
+| — | — | — | *None yet — add a row when archiving via `/archive-roadmap-item`.* |

--- a/docs/templates/roadmap_item.md
+++ b/docs/templates/roadmap_item.md
@@ -1,0 +1,97 @@
+# Epic: [SHORT TITLE]
+
+| Field | Value |
+|-------|-------|
+| **Status** | Proposed \| Not Started \| In Progress \| Done \| Closed |
+| **Horizon** | Now \| Next \| Then \| Policy \| Deferred \| Watchlist |
+| **Priority** | P0 \| P1 \| P2 (optional; align with `docs/roadmap/README.md`) |
+| **Upstream** | Links to upstream release/PR when parity-related (or “N/A”) |
+| **Dependencies** | Roadmap file links (e.g. `./POL-01-tool-count-policy.md`) or `docs/` anchors only — avoid vague “team X” |
+
+**Closed** is reserved for items in **`docs/roadmap/archive/`** after **`/archive-roadmap-item`**.
+
+## Problem
+
+[User-visible or operator-visible gap; one tight paragraph.]
+
+## Outcome
+
+[Measurable theme; what “done” means for users/agents.]
+
+## Scope
+
+### In scope
+
+- [Bullet list]
+
+### Out of scope
+
+- [Explicit non-goals]
+
+## Dependencies
+
+- [Technical or sequencing deps; use roadmap IDs or doc paths, e.g. `docs/auth-and-scopes.md`]
+
+## Acceptance criteria (Gherkin)
+
+Every AC must be **testable** (implementable as `_test.go`, integration test, or verifiable doc/checklist). No vague language (“fast”, “robust”, “handles errors well”).
+
+### AC1: [Name]
+
+```gherkin
+Given [precondition]
+When [action]
+Then [observable outcome]
+```
+
+### AC2: [Name]
+
+```gherkin
+Given [precondition]
+When [action]
+Then [observable outcome]
+```
+
+[Add ACs for error paths, destructive vs read-only tools, OAuth/scopes boundaries, and concurrency if relevant.]
+
+## Implementation notes
+
+Ground every claim in the **current** repo (file paths, symbols). This server has **no SQL migrations**; persistence is OAuth tokens and runtime config.
+
+### MCP tool surface
+
+- Tools to add/change/remove (exact `snake_case` names; SEP-986).
+- `ReadOnlyHint` / `DestructiveHint` / `IdempotentHint` / `OpenWorldHint` expectations.
+- Dual-output (`structuredContent`) vs text-only per `docs/code-patterns.md`.
+
+### Packages and registration
+
+- `internal/tools/[service]/` handlers and `Register` patterns.
+- `internal/registry/registry.go` — tier/service filters, name validation.
+- `internal/services/factory.go` — client construction and caching.
+- `configs/tool_tiers.yaml` — tier membership if applicable.
+
+### Auth and transport
+
+- `internal/auth/*`, `internal/config/*` — env vars, callback URLs, scopes in `internal/auth/scopes.go`.
+- `cmd/server/main.go` — transport, middleware wiring.
+
+### Verification
+
+- Commands: `golangci-lint run ./...`, `go test -race ./...`, and `-tags=integration` when OAuth/API mocks apply.
+
+## Component inventory
+
+| Path | Change |
+|------|--------|
+| `path/to/file.go` | New \| Modified \| Removed |
+
+## Existing infrastructure to reuse
+
+- Response builder, middleware (`internal/middleware/*`), shared helpers (`internal/pkg/*`), comment tools pattern (`internal/tools/comments/`), etc. — list **concrete** symbols or files to extend.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| [Realistic, codebase-informed] | [Who/what breaks] | [Concrete] |


### PR DESCRIPTION
## Summary

This pull request introduces the `docs/roadmap/` planning tree and hardens every epic to match `docs/templates/roadmap_item.md`: Gherkin acceptance criteria, explicit scope, implementation notes grounded in this repository, component inventory, risks, and **Priority** metadata.

## Roadmap overview (`docs/roadmap/README.md`)

- **Seq** column: recommended merge order within horizons (**AUTH-01 → SEC-01 → DRV-01 → CON-01**).
- **Sequencing rules**: `POL-01` must be decided before `PAR-01` implementation merges; `DOC-01` sequencing clarified.
- **Items index**: includes **Priority** (P0–P3) aligned with each file.

## Other changes

- `docs/templates/roadmap_item.md`: canonical epic template (referenced by the roadmap README and PM `/harden` command).
- `CHANGELOG.md`: `[Unreleased]` notes for the above; **SEC-01** upstream traceability corrected to [PR #682](https://github.com/taylorwilsdon/google_workspace_mcp/pull/682).
- `docs/roadmap/archive/README.md`: placeholder archive index for future `/archive-roadmap-item` use.

## Testing

Documentation-only; no code paths changed.

Made with [Cursor](https://cursor.com)