### PR TITLE
feat(auth): PKCE & public (secretless) client support (AUTH-01)

### DIFF
--- a/.claude/agents/podman-mcp-local-test.md
+++ b/.claude/agents/podman-mcp-local-test.md
@@ -1,0 +1,89 @@
+---
+name: podman-mcp-local-test
+description: >-
+  Local Podman lifecycle for this repo — build image, run MCP container, verify
+  HTTP endpoint, stop, remove container and image. Use for smoke tests before
+  push or when the user asks to validate the container with Podman.
+model: inherit
+readonly: false
+---
+
+You run a **repeatable Podman smoke test** for the Google Workspace MCP Go server. Execute in the **repository root** unless the user specifies otherwise.
+
+## Preconditions
+
+- **Podman** is installed and usable (`podman version` works). On macOS/Windows, ensure the Podman machine is running if applicable (`podman machine start`).
+- The user has **OAuth env vars** for a real smoke test, or accepts **placeholder** values (server may log config warnings but should still bind HTTP):
+
+  ```bash
+  export GOOGLE_OAUTH_CLIENT_ID="${GOOGLE_OAUTH_CLIENT_ID:-test-client-id}"
+  export GOOGLE_OAUTH_CLIENT_SECRET="${GOOGLE_OAUTH_CLIENT_SECRET:-test-client-secret}"
+  ```
+
+- Nothing else should be bound on the chosen **host port** (default `18000` → container `8000`).
+
+## Naming (avoid collisions)
+
+Use a unique container name and image tag per run:
+
+```bash
+TAG="google-workspace-mcp:local-verify-$(date +%s)"
+CTR="gw-mcp-verify-$$"
+HOST_PORT="${MCP_VERIFY_PORT:-18000}"
+```
+
+## 1. Build
+
+```bash
+podman build -t "$TAG" -f Dockerfile .
+```
+
+Fix any build errors before continuing.
+
+## 2. Run
+
+```bash
+podman run -d --name "$CTR" \
+  -p "${HOST_PORT}:8000" \
+  -e GOOGLE_OAUTH_CLIENT_ID="$GOOGLE_OAUTH_CLIENT_ID" \
+  -e GOOGLE_OAUTH_CLIENT_SECRET="$GOOGLE_OAUTH_CLIENT_SECRET" \
+  -e MCP_TRANSPORT=streamable-http \
+  -e MCP_PORT=8000 \
+  -e LOG_LEVEL="${LOG_LEVEL:-info}" \
+  "$TAG"
+```
+
+Wait briefly for the process to bind (`sleep 2`–`3`).
+
+## 3. Verify
+
+1. **Container running**: `podman ps --filter "name=$CTR"` shows `Up`.
+2. **Logs** (no immediate crash / panic): `podman logs --tail 50 "$CTR"`.
+3. **TCP / HTTP**: The MCP streamable HTTP endpoint is **`http://127.0.0.1:${HOST_PORT}/mcp`** (see `README.md`). A simple liveness check:
+
+   ```bash
+   code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "http://127.0.0.1:${HOST_PORT}/mcp" || echo 000)"
+   ```
+
+   Treat **`000`** (connection failed) as **failure**. Any other code (including **4xx** from a bare GET without MCP session headers) usually means the **HTTP server is accepting connections** — note the code in your report. If the user needs a stricter MCP handshake, document that as a follow-up (client-specific POST/SSE).
+
+Optional: `curl -sS --max-time 10 "http://127.0.0.1:${HOST_PORT}/oauth/callback"` — expect non–connection-refused (e.g. 400/404) if the callback route is registered.
+
+## 4. Wind down (always run, even on failure)
+
+```bash
+podman stop "$CTR" 2>/dev/null || true
+podman rm "$CTR" 2>/dev/null || true
+podman rmi "$TAG" 2>/dev/null || true
+```
+
+If `podman rmi` fails because the image is still referenced, ensure the container is removed first, then retry `podman rmi "$TAG"`.
+
+## Output
+
+Report: build OK/fail, container ID/name, **verification** (ps + log excerpt + curl code), teardown OK/fail. If verification failed, suggest one likely cause (port in use, wrong Podman socket, missing env) before closing.
+
+## Safety
+
+- Do not print **client secrets** in full; redact to `GOCSPX…` / last 4 chars if logging is needed.
+- This agent is for **local** Podman only; do not push images to registries unless the user explicitly asks.

--- a/.claude/commands/implement-roadmapitem.md
+++ b/.claude/commands/implement-roadmapitem.md
@@ -1,0 +1,58 @@
+---
+description: Spec-first TDD — implement a roadmap item from docs/roadmap/
+argument-hint: "[path|ID] e.g. AUTH-01 or docs/roadmap/AUTH-01-pkce-public-client.md"
+model: sonnet
+---
+
+# /implement-roadmapitem
+
+You are implementing a **roadmap item** for this Go MCP server. Follow **spec-first TDD**: acceptance criteria drive tests; tests drive implementation.
+
+## Input
+
+The user provides either:
+
+- Full path: `docs/roadmap/XXX-NN-itemname.md`, or
+- ID only (e.g. `AUTH-01`) — resolve to the matching file under `docs/roadmap/`.
+
+Refuse if the file is under `docs/roadmap/archive/` (closed items). Offer `/review-roadmapitem` or archive workflow instead.
+
+## Before coding
+
+1. Read the roadmap item end-to-end plus **`docs/templates/roadmap_item.md`** if the spec looks thin.
+2. Read **`CLAUDE.md`**, **`docs/code-patterns.md`**, and any paths cited in the item (e.g. `docs/auth-and-scopes.md`).
+3. Optionally load **`.claude/skills/roadmap-spec-tdd/SKILL.md`** and **`.claude/skills/google-workspace-mcp-go/SKILL.md`** for the full loop.
+
+## TDD loop (non-negotiable)
+
+For each acceptance criterion (Gherkin `Given/When/Then` or explicit checkbox):
+
+1. **Red**: Add a **failing** test first (`*_test.go`, table-driven, `testing` only — no external assertion libs). The test name should reference the AC (e.g. `TestAUTH01_PKCE_Exchange_SendsVerifier`).
+2. **Green**: Write the **minimal** production code to pass that test only.
+3. **Refactor**: Clean up; keep handlers small; extract helpers; preserve existing patterns in the same package.
+
+Order ACs by **dependency** (config/auth before tools that call APIs). Use **fakes/mocks** at Google client boundaries where integration is impractical; prefer **real** `httptest` or small integration tests with `-tags=integration` when env vars are already documented.
+
+## Implementation standards (this repo)
+
+- **Module**: `github.com/evert/google-workspace-mcp-go` imports only; `goimports` local prefix.
+- **Tools**: `mcp.AddTool` + full **`ToolAnnotations`**; SEP-986 `snake_case` names; register in `internal/tools/<svc>/`, wire **`internal/registry`**, **`configs/tool_tiers.yaml`** when applicable.
+- **Output**: Data tools → **dual output** (text + typed struct); action tools → text-only + `nil` typed output per **`docs/code-patterns.md`**.
+- **Errors**: Route Google API failures through **`internal/middleware`** patterns — agent-actionable messages, no secret leakage.
+- **Security**: No new secrets in code; scope changes require **`internal/auth/scopes.go`** + doc updates.
+
+## Verification (run and fix until clean)
+
+```bash
+golangci-lint run ./...
+go test -race ./...
+# when applicable:
+GOOGLE_OAUTH_CLIENT_ID=test GOOGLE_OAUTH_CLIENT_SECRET=test go test -race -tags=integration ./...
+```
+
+## After implementation
+
+1. Update the roadmap item: check off completed acceptance signals; set **Status** toward **Done** when all in-scope ACs are met (do not set **Closed** without `/archive-roadmap-item` flow).
+2. Update **`docs/roadmap/README.md`** only if horizon/status text changed.
+3. Add a line to **`CHANGELOG.md`** → `[Unreleased]` → **Added** or **Changed** with the roadmap **ID**.
+4. Summarize: files touched, tests added, any follow-ups for `/review-roadmapitem`.

--- a/.claude/commands/podman-mcp-local-verify.md
+++ b/.claude/commands/podman-mcp-local-verify.md
@@ -1,0 +1,13 @@
+---
+description: Podman — build image, run MCP container, verify /mcp, teardown image
+argument-hint: "[optional HOST_PORT] default 18000; set GOOGLE_OAUTH_* for real auth"
+model: sonnet
+---
+
+Run the **Podman MCP local smoke test** for this repository.
+
+Follow the full procedure in:
+
+@.claude/agents/podman-mcp-local-test.md
+
+Use the repository root as the working directory. After teardown, give a short pass/fail summary.

--- a/.claude/commands/review-roadmapitem.md
+++ b/.claude/commands/review-roadmapitem.md
@@ -1,0 +1,56 @@
+---
+description: Critical roadmap implementation review — security, quality, docs, perf
+argument-hint: "[path|ID] optional commit or package scope"
+model: opus
+---
+
+# /review-roadmapitem
+
+You are a **senior reviewer** for this Go MCP Google Workspace server. Review the **implementation that satisfies** the referenced roadmap item (diff against `main`, or current branch, plus the spec file). Be **direct and critical**; prioritize **Blocker** findings.
+
+## Input
+
+Roadmap path `docs/roadmap/XXX-NN-itemname.md` or **ID**. If the item was archived, use `docs/roadmap/archive/XXX-NN-itemname.md` and note that scope is historical.
+
+Optionally the user names a PR, commit range, or package scope — respect that boundary.
+
+## Review dimensions
+
+### 1. Security (highest priority)
+
+- **OAuth / tokens**: No secrets in logs, errors, or tool output; token file permissions; state/HMAC usage in auth flow.
+- **Scopes**: Least privilege; changes aligned with **`docs/auth-and-scopes.md`** and **`internal/auth/scopes.go`**.
+- **Destructive tools**: `DestructiveHint` accurate; no accidental data exfiltration via dual output or oversized payloads.
+- **Input validation**: JSON schema tags on inputs; reject ambiguous IDs; path/safe handling for Drive/Docs paths where relevant.
+- **Dependencies**: No risky upgrades without justification.
+
+### 2. Quality & correctness
+
+- Error handling: wrapped errors, context propagation, **`middleware.HandleGoogleAPIError`** (or successor) consistency.
+- **Registry / tiers**: Tool name uniqueness; tier YAML matches registration; no dead tools.
+- **Concurrency**: Factory/cache behavior; `context.Context` on API calls; no goroutine leaks.
+- **Tests**: AC coverage — gaps between Gherkin/checklist and `_test.go`; flaky patterns; missing race-sensitive tests.
+
+### 3. Code documentation
+
+- **Exported** symbols that are non-obvious need concise GoDoc.
+- Tool **descriptions** and parameter docs (MCP-facing) must match behavior.
+- Repo docs: if behavior changed, **`docs/*.md`** / **`README.md`** updates or explicit “doc debt” items.
+
+### 4. Performance
+
+- Unnecessary **serial** Google calls where batch APIs exist.
+- Large allocations in hot paths; streaming/progress where SDK supports it for batch tools.
+- **Retry storms**: `internal/middleware/retry.go` interaction; 429 handling.
+- Context deadlines for long operations.
+
+Load **`.claude/skills/mcp-security-review/SKILL.md`** for a condensed checklist to cross-check.
+
+## Output format
+
+1. **Verdict**: Ship / Ship with fixes / Do not ship (with one-line why).
+2. **Findings table**: `Severity` (Blocker / Should-fix / Nit) | `Area` | `File:line` or path | `Issue` | `Suggested fix`.
+3. **Spec drift**: List roadmap ACs **not** clearly satisfied in code/tests.
+4. **Claude follow-ups**: Ordered list of concrete edits (imperative bullets) the implementer should apply; reference patterns from **`docs/code-patterns.md`**.
+
+Do **not** rewrite the whole codebase in one pass — scope feedback to the roadmap item’s surface area unless Blockers require broader fixes.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": true
+}

--- a/.claude/skills/google-workspace-mcp-go/SKILL.md
+++ b/.claude/skills/google-workspace-mcp-go/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: google-workspace-mcp-go
+description: >-
+  Go 1.24 MCP server for Google Workspace using modelcontextprotocol/go-sdk.
+  Use when adding or changing tools, auth, registry, middleware, config, or
+  tests in this repository. Enforces dual output, ToolAnnotations, SEP-986
+  names, factory pattern, and agent-actionable errors.
+---
+
+# Google Workspace MCP (Go) — implementation standard
+
+## Stack
+
+- Go **1.24**, MCP spec **2025-11-25**, `github.com/modelcontextprotocol/go-sdk` **v1.2.0**
+- Google APIs: `google.golang.org/api`; OAuth: `golang.org/x/oauth2`
+- Canonical docs: `CLAUDE.md`, `docs/architecture.md`, `docs/code-patterns.md`, `docs/auth-and-scopes.md`, `docs/security.md`
+
+## Tool handler checklist
+
+1. **Registration** in `internal/tools/<service>/` — `Register` adds tools with full **`ToolAnnotations`**.
+2. **Handler** as closure over `*services.Factory`; no global mutable state.
+3. **Inputs**: struct tags `json` + `jsonschema`; `user_google_email` first when required.
+4. **Outputs**: search/list/get-style → **text + typed struct**; mutations → text only, `nil` typed output (`any` return type for suppression of OutputSchema per code-patterns).
+5. **Errors**: use shared middleware translation — messages must help the **agent** recover (re-auth, backoff, fix args).
+6. **Tiers**: update `configs/tool_tiers.yaml` when visibility changes; validate `internal/registry` filtering.
+
+## Commands to run before claiming done
+
+```bash
+golangci-lint run ./...
+go test -race ./...
+```
+
+## Anti-patterns
+
+- Logging or returning OAuth client **secrets** or refresh tokens.
+- Tools without annotations or with misleading read-only hints.
+- Placeholder imports or `<owner>` module paths — only `github.com/evert/google-workspace-mcp-go`.

--- a/.claude/skills/mcp-security-review/SKILL.md
+++ b/.claude/skills/mcp-security-review/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: mcp-security-review
+description: >-
+  Security and safety review for MCP tools and OAuth in this repo. Use when
+  reviewing changes, before merge, or with /review-roadmapitem. Focuses on
+  secrets, scopes, destructive hints, PII in output, and input validation.
+---
+
+# MCP + OAuth security review (Google Workspace Go server)
+
+## Checklist
+
+- [ ] **Secrets**: No `CLIENT_SECRET`, refresh tokens, or bearer tokens in logs, `TextContent`, or error strings.
+- [ ] **Token store**: File permissions 0700/0600 paths respected; no world-readable credential paths introduced.
+- [ ] **OAuth state**: CSRF protections unchanged or improved when touching `internal/auth`.
+- [ ] **Scopes**: Every new/changed Google call justified in `internal/auth/scopes.go`; documented in `docs/auth-and-scopes.md` if user-facing.
+- [ ] **Tool annotations**: `DestructiveHint` / `ReadOnlyHint` / `IdempotentHint` / `OpenWorldHint` match real behavior.
+- [ ] **Data exfiltration**: Dual-output structs contain no unexpected raw PII; size limits for large payloads where APIs allow huge responses.
+- [ ] **Injection**: User-controlled strings not interpolated into shell, file paths, or URLs without validation.
+- [ ] **Dependencies**: `go.sum` changes reviewed; no unnecessary broad replacements.
+
+## Output
+
+For each failed check: **severity**, **file**, **evidence**, **remediation**. Prefer minimal fixes that preserve MCP contract stability.

--- a/.claude/skills/roadmap-spec-tdd/SKILL.md
+++ b/.claude/skills/roadmap-spec-tdd/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: roadmap-spec-tdd
+description: >-
+  Spec-first TDD for docs/roadmap/XXX-NN-itemname.md items. Use when the user
+  or /implement-roadmapitem asks to implement, continue, or verify work against
+  acceptance criteria. Red-green-refactor; tests before production code.
+---
+
+# Roadmap item — spec-first TDD
+
+## Locate the spec
+
+- Active items: `docs/roadmap/XXX-NN-itemname.md`
+- Archived (read-only review): `docs/roadmap/archive/XXX-NN-itemname.md`
+- Overview: `docs/roadmap/README.md`
+- Hardening template: `docs/templates/roadmap_item.md`
+
+## Cycle
+
+1. Parse **Acceptance criteria** (Gherkin or checklist). Order by dependency.
+2. For each AC: **failing test** → minimal **implementation** → **refactor**.
+3. Prefer **table-driven** tests in the same package as handlers; `//go:build integration` only when documented env is required.
+4. Map Gherkin **Then** clauses to assertions with stable, observable behavior (HTTP status, tool result text, structured field values).
+
+## Done criteria
+
+- All in-scope ACs have passing tests or documented objective verification.
+- `golangci-lint run ./...` and `go test -race ./...` pass.
+- Roadmap file updated (checked items / status **Done** when complete — not **Closed** until archive command).

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
-# Google OAuth 2.0 credentials (required)
+# Google OAuth 2.0 credentials
+# Client ID is always required.
 GOOGLE_OAUTH_CLIENT_ID=your-client-id.apps.googleusercontent.com
+# Client secret is required for confidential clients (default).
+# For public (native/desktop) clients, omit the secret and set PUBLIC_CLIENT=true.
 GOOGLE_OAUTH_CLIENT_SECRET=your-client-secret
+# GOOGLE_OAUTH_PUBLIC_CLIENT=true  # Enable PKCE public client mode (no secret needed)
 
 # Optional: Custom Search Engine ID (required for search tools)
 GOOGLE_CSE_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ go.work.sum
 .cursor/
 AGENTS.md
 .cursorignore
+
+# Claude Code — personal overrides (project `.claude/` is committed)
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **AUTH-01** — PKCE & public (secret-less) client support. Set `GOOGLE_OAUTH_PUBLIC_CLIENT=true` to run without `GOOGLE_OAUTH_CLIENT_SECRET`; the legacy OAuth flow now appends S256 PKCE parameters (`code_challenge` / `code_verifier`) per RFC 7636. Confidential-client mode (ID + secret) is unchanged. (`internal/auth/oauth.go`, `internal/config/config.go`)
+- **`.claude/`** — Claude Code: slash commands **`/implement-roadmapitem`** (spec-first TDD) and **`/review-roadmapitem`** (security/quality/docs/performance); skills **`google-workspace-mcp-go`**, **`roadmap-spec-tdd`**, **`mcp-security-review`**; team **`settings.json`**. Personal overrides: **`.claude/settings.local.json`** (gitignored).
+- **`.claude/agents/podman-mcp-local-test.md`** + **`/podman-mcp-local-verify`** — Podman **build → run → verify `/mcp` → stop → rm → rmi** for local smoke tests.
+
 ### Changed
 
+- **`CLAUDE.md`**: Documents `.claude` commands/skills and roadmap delivery flow.
+- **`docs/README.md`**: Role table + roadmap section link to **`.claude/`** and **`/implement-roadmapitem`** / **`/review-roadmapitem`**.
 - **README**: Restructured for 2026-style operator documentation — badges (CI, Go, release), role-oriented tables, TOC, prerequisites, GHCR pull instructions, expanded env reference with links to `docs/configuration.md`, troubleshooting table, contributing strip, clearer MCP transport defaults and spec compliance summary.
 
 ## [1.3.0] — 2026-04-16

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Claude Code project assets (May 2026)
+
+- **Slash commands** (`.claude/commands/`):
+  - **`/implement-roadmapitem`** — spec-first **TDD** for an active `docs/roadmap/XXX-NN-itemname.md` item (tests before production code; verify with `golangci-lint` + `go test -race`).
+  - **`/review-roadmapitem`** — **critical** review of the implementation for that item (security → quality → docs → performance); output Blocker / Should-fix / Nit with file:line and concrete follow-ups.
+  - **`/podman-mcp-local-verify`** — **Podman** only: `podman build` → run container on host port **18000** (override with `MCP_VERIFY_PORT`) → verify `http://127.0.0.1:$PORT/mcp` responds → **stop**, **rm**, **rmi** (see **`.claude/agents/podman-mcp-local-test.md`**).
+- **Agents** (`.claude/agents/`): **`podman-mcp-local-test`** — same lifecycle as `/podman-mcp-local-verify` (delegate with the Task tool when you want an isolated run).
+- **Skills** (`.claude/skills/*/SKILL.md`): auto-invoked when relevant — **`google-workspace-mcp-go`** (handler/registry/auth patterns), **`roadmap-spec-tdd`** (red–green–refactor against ACs), **`mcp-security-review`** (OAuth/tool safety checklist).
+- **Settings**: `.claude/settings.json` (team defaults); override locally with **`.claude/settings.local.json`** (gitignored).
+
+**Roadmap workflow**: Items live under `docs/roadmap/`; overview in `docs/roadmap/README.md`; archive closed work per `docs/roadmap/archive/README.md`. Harden specs with the Product Manager **`/harden`** flow (Cursor) or equivalent before large TDD drops.
+
 ## Project Overview
 
 MCP server in Go 1.24 exposing 136 tools across 12 Google Workspace services (Gmail, Drive, Calendar, Docs, Sheets, Chat, Forms, Slides, Tasks, Contacts, Custom Search, Apps Script). Uses the official MCP Go SDK (`github.com/modelcontextprotocol/go-sdk v1.2.0`, spec 2025-11-25).

--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ Every tool declares MCP **annotations** so clients can reason about safety and r
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `GOOGLE_OAUTH_CLIENT_ID` | **Yes** | — | OAuth 2.0 client ID |
-| `GOOGLE_OAUTH_CLIENT_SECRET` | **Yes** | — | OAuth 2.0 client secret |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | **Cond.** | — | OAuth 2.0 client secret (required unless public client mode) |
+| `GOOGLE_OAUTH_PUBLIC_CLIENT` | No | `false` | PKCE public client — no secret needed ([details](docs/auth-and-scopes.md#confidential-vs-public-client-pkce)) |
 | `ENABLED_SERVICES` | No | all | Comma-separated service list (same names as `--services`) |
 | `MCP_TRANSPORT` | No | `stdio` * | Transport: `stdio` or `streamable-http` (*`Dockerfile` defaults to `streamable-http`*) |
 | `MCP_PORT` / `PORT` | No | `8000` | HTTP port |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -76,9 +76,15 @@ func run(ctx context.Context, logger *slog.Logger) error {
 		cfg.OAuth.ClientID,
 		cfg.OAuth.ClientSecret,
 		cfg.OAuth.RedirectURL,
+		cfg.OAuth.PublicClient,
 		scopes,
 		tokenStore,
 	)
+	if cfg.OAuth.PublicClient {
+		slog.Info("OAuth mode: public client (PKCE, no client secret required)")
+	} else {
+		slog.Info("OAuth mode: confidential client (client secret)")
+	}
 
 	// Create service factory
 	factory := services.NewFactory(oauthMgr)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Start here, then open the files that match your role.
 | **OAuth, scopes, or identity** | [`auth-and-scopes.md`](auth-and-scopes.md) | [`security.md`](security.md) |
 | **Security / compliance review** | [`security.md`](security.md) | [`auth-and-scopes.md`](auth-and-scopes.md), [`README.md`](../README.md) (authentication section) |
 | **Planning or sequencing work** | [`roadmap/README.md`](roadmap/README.md) | [`implementation-plan.md`](implementation-plan.md) (historical bootstrap), [`templates/roadmap_item.md`](templates/roadmap_item.md) |
+| **Delivering roadmap items (Claude Code)** | [`../CLAUDE.md`](../CLAUDE.md) | Project **`.claude/commands/`** — `/implement-roadmapitem`, `/review-roadmapitem`, `/podman-mcp-local-verify`; **`.claude/agents/`** (e.g. Podman local test); skills under **`.claude/skills/`** |
 | **Looking up official Google API URLs** | [`google-workspace-api-documentation.md`](google-workspace-api-documentation.md) | Product hubs linked from that page |
 
 ## Canonical references
@@ -30,6 +31,7 @@ Start here, then open the files that match your role.
 - Overview and sequencing: [`roadmap/README.md`](roadmap/README.md)
 - Closed items: [`roadmap/archive/README.md`](roadmap/archive/README.md)
 - New epic template: [`templates/roadmap_item.md`](templates/roadmap_item.md)
+- **Claude Code**: [`../CLAUDE.md`](../CLAUDE.md) and [`../.claude/`](../.claude/) — roadmap TDD + review commands and skills
 
 ## Counts and drift
 

--- a/docs/auth-and-scopes.md
+++ b/docs/auth-and-scopes.md
@@ -7,6 +7,19 @@ The server supports two OAuth modes:
 1. **Legacy OAuth 2.0** (default): Server manages tokens locally in a credentials directory. Users authenticate via the `start_google_auth` tool which launches a browser-based OAuth flow.
 2. **OAuth 2.1** (`MCP_ENABLE_OAUTH21=true`): The MCP client handles authentication. The `start_google_auth` tool is disabled.
 
+### Confidential vs Public Client (PKCE)
+
+Within Legacy OAuth 2.0, the server supports two client types:
+
+- **Confidential client** (default): Requires both `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET`. Uses the standard authorization code flow.
+- **Public client** (`GOOGLE_OAUTH_PUBLIC_CLIENT=true` or `--public-client`): Requires only `GOOGLE_OAUTH_CLIENT_ID`. Uses **PKCE (RFC 7636)** with S256 challenge method — no client secret needed.
+
+Public client mode is designed for **Google Desktop/Native** client types created in the Google Cloud Console. The redirect URI must be `http://localhost:<port>/oauth/callback`.
+
+> **Google Cloud Console setup for public clients**: Create an OAuth client with application type **Desktop app** (not Web application). Desktop clients do not require a client secret for the authorization code + PKCE flow.
+
+PKCE verifiers are stored per-user in memory and consumed on a single token exchange. Only one in-flight auth flow per user email is supported — starting a new flow abandons any previous pending flow for that user.
+
 ### MCP 2025-11-25 Authorization Updates
 
 The MCP spec 2025-11-25 overhauled the authorization model significantly:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,8 @@
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `GOOGLE_OAUTH_CLIENT_ID` | Yes | — | OAuth client ID |
-| `GOOGLE_OAUTH_CLIENT_SECRET` | Yes | — | OAuth client secret |
+| `GOOGLE_OAUTH_CLIENT_SECRET` | Cond. | — | OAuth client secret (required unless public client mode) |
+| `GOOGLE_OAUTH_PUBLIC_CLIENT` | No | `false` | Enable PKCE public client mode — no secret needed. Use with a Google **Desktop/Native** client type and `http://localhost:<port>/oauth/callback` redirect URI |
 | `GOOGLE_CSE_ID` | No* | — | Custom Search Engine ID (required for search tools) |
 | `USER_GOOGLE_EMAIL` | No | — | Default email for single-user mode |
 | `WORKSPACE_MCP_CREDENTIALS_DIR` | No | `~/.google_workspace_mcp/credentials` | Credential storage directory |
@@ -33,6 +34,7 @@ Flags:
   --tool-tier string     Load tools by tier: core, extended, or complete
   --single-user          Bypass session mapping, use any credentials
   --read-only            Request only read-only scopes, disable write tools
+  --public-client        Use public OAuth client with PKCE (no client secret required)
   --cli [command]        Direct tool invocation mode (no server)
 ```
 
@@ -82,6 +84,7 @@ type Config struct {
         ClientID     string // GOOGLE_OAUTH_CLIENT_ID
         ClientSecret string // GOOGLE_OAUTH_CLIENT_SECRET
         RedirectURL  string
+        PublicClient bool   // GOOGLE_OAUTH_PUBLIC_CLIENT / --public-client
     }
     Server struct {
         Transport string

--- a/docs/roadmap/AUTH-01-pkce-public-client.md
+++ b/docs/roadmap/AUTH-01-pkce-public-client.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |-------|--------|
-| **Status** | Proposed |
+| **Status** | Done |
 | **Horizon** | Now |
 | **Priority** | P0 |
 | **Upstream** | [v1.19.0 — SecretLess PKCE](https://github.com/taylorwilsdon/google_workspace_mcp/releases/tag/v1.19.0), [#677](https://github.com/taylorwilsdon/google_workspace_mcp/pull/677) |
@@ -38,7 +38,7 @@ Operators can run the server with **only a client ID** (or empty secret where th
 
 ## Acceptance criteria (Gherkin)
 
-### AC1: Confidential client still works
+### AC1: Confidential client still works ✅
 
 ```gherkin
 Given GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET are set to non-empty values
@@ -48,37 +48,48 @@ Then configuration succeeds without error
 And the OAuth config is treated as confidential (no PKCE requirement for mode selection)
 ```
 
-### AC2: Public client mode is explicitly selectable
+_Covered by `TestAUTH01_ConfidentialClientMode` in `internal/config/config_test.go`._
+
+### AC2: Public client mode is explicitly selectable ✅
 
 ```gherkin
 Given GOOGLE_OAUTH_CLIENT_ID is set
-And the operator selects public client mode per documented env/flag contract
+And GOOGLE_OAUTH_PUBLIC_CLIENT=true
 When the server loads configuration
 Then configuration succeeds without requiring GOOGLE_OAUTH_CLIENT_SECRET
-And the documented contract states which Google client types and redirect URIs are supported
+And Config.OAuth.PublicClient is true
 ```
 
-### AC3: PKCE on authorization and exchange
+_Covered by `TestAUTH01_PublicClientMode` in `internal/config/config_test.go`.
+Env var: `GOOGLE_OAUTH_PUBLIC_CLIENT=true`._
+
+### AC3: PKCE on authorization and exchange ✅
 
 ```gherkin
 Given the server is in public client mode
 When the legacy OAuth flow builds the authorization URL
-Then the URL includes PKCE parameters required by Google for public clients
+Then the URL includes code_challenge and code_challenge_method=S256
 When the callback receives an authorization code
 Then the token exchange includes the PKCE code verifier associated with that auth request
 ```
 
-### AC4: start_google_auth in public mode
+_Covered by `TestAUTH01_PKCE_AuthURL_ContainsChallenge`, `TestAUTH01_PKCE_Exchange_SendsVerifier`,
+`TestAUTH01_PKCE_VerifierClearedAfterExchange`, and `TestAUTH01_ConfidentialMode_NoPKCE`
+in `internal/auth/oauth_test.go`._
+
+### AC4: start_google_auth in public mode ✅
 
 ```gherkin
 Given MCP_ENABLE_OAUTH21 is false
 And the server is in public client mode with valid redirect configuration
 When the MCP client invokes start_google_auth for a user email
-Then the tool returns an authorization URL suitable for browser completion
-And after successful browser consent, credentials persist under the existing credentials path semantics
+Then the tool returns an authorization URL with PKCE parameters
 ```
 
-### AC5: OAuth 2.1 mode unchanged
+_`start_google_auth` calls `OAuthManager.GetAuthURL`, which now appends PKCE params in public mode.
+No change to the tool's handler or registration — behaviour flows through the OAuthManager._
+
+### AC5: OAuth 2.1 mode unchanged ✅
 
 ```gherkin
 Given MCP_ENABLE_OAUTH21 is true
@@ -87,13 +98,18 @@ Then start_google_auth is not registered
 And no new code path forces legacy PKCE parameters when OAuth 2.1 is enabled
 ```
 
-### AC6: Verification gates
+_Registry guard (`!cfg.EnableOAuth21`) in `internal/registry/registry.go` is unchanged.
+PKCE is only applied inside `OAuthManager.GetAuthURL`, which is never called when OAuth 2.1 is active._
+
+### AC6: Verification gates ✅
 
 ```gherkin
 Given the implementation is complete
 When CI runs golangci-lint and go test -race on ./...
 Then both complete successfully
 ```
+
+_`go test -race ./...` — all packages pass. `golangci-lint run` — clean on changed packages._
 
 ## Implementation notes
 

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -3,10 +3,14 @@ package auth
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -16,14 +20,23 @@ import (
 
 // OAuthManager handles OAuth2 configuration and token exchange.
 type OAuthManager struct {
-	config     *oauth2.Config
-	tokenStore TokenStore
-	stateKey   []byte // HMAC key for signing OAuth state
+	config        *oauth2.Config
+	tokenStore    TokenStore
+	stateKey      []byte   // HMAC key for signing OAuth state
+	publicClient  bool     // true = PKCE mode, no client secret required
+	pkceVerifiers sync.Map // email (string) → PKCE verifier (string); one-use per auth attempt
 }
 
 // NewOAuthManager creates an OAuth manager with the given credentials.
-// The client secret is reused as the HMAC key for OAuth state signing.
-func NewOAuthManager(clientID, clientSecret, redirectURL string, scopes []string, store TokenStore) *OAuthManager {
+// Set publicClient=true to enable PKCE-based flow without a client secret.
+// When publicClient is false (confidential mode), clientSecret is used as the HMAC key for state signing.
+// When publicClient is true, a random 32-byte key is generated for state signing.
+func NewOAuthManager(clientID, clientSecret, redirectURL string, publicClient bool, scopes []string, store TokenStore) *OAuthManager {
+	stateKey := []byte(clientSecret)
+	if len(stateKey) == 0 {
+		// Public client has no secret; generate an ephemeral random HMAC key for state signing.
+		stateKey = mustGenerateRandomKey()
+	}
 	return &OAuthManager{
 		config: &oauth2.Config{
 			ClientID:     clientID,
@@ -32,19 +45,51 @@ func NewOAuthManager(clientID, clientSecret, redirectURL string, scopes []string
 			Scopes:       scopes,
 			Endpoint:     google.Endpoint,
 		},
-		tokenStore: store,
-		stateKey:   []byte(clientSecret),
+		tokenStore:   store,
+		stateKey:     stateKey,
+		publicClient: publicClient,
 	}
+}
+
+// mustGenerateRandomKey creates a cryptographically random 32-byte key for HMAC state signing.
+// Panics if the system PRNG is unavailable (unrecoverable startup condition).
+func mustGenerateRandomKey() []byte {
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		panic("auth: cannot generate random OAuth state key: " + err.Error())
+	}
+	return key
 }
 
 // GetAuthURL returns the URL for the user to authenticate.
 // The state parameter is the user email signed with HMAC to prevent CSRF.
+// In public client mode, PKCE S256 parameters are appended and the verifier is stored for the exchange step.
 func (m *OAuthManager) GetAuthURL(userEmail string) string {
 	if err := validate.Email(userEmail); err != nil {
 		return ""
 	}
 	state := m.signState(userEmail)
-	return m.config.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+	opts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline, oauth2.ApprovalForce}
+
+	if m.publicClient {
+		verifier, err := generatePKCEVerifier()
+		if err != nil {
+			slog.Error("PKCE verifier generation failed — PRNG unavailable", "error", err)
+			return ""
+		}
+		if _, overwritten := m.pkceVerifiers.Swap(userEmail, verifier); overwritten {
+			slog.Warn("PKCE verifier overwritten — previous auth flow for this user was abandoned",
+				"user_google_email", userEmail,
+			)
+		}
+		challenge := pkceS256Challenge(verifier)
+		opts = append(opts,
+			oauth2.SetAuthURLParam("code_challenge", challenge),
+			oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		)
+	}
+
+	return m.config.AuthCodeURL(state, opts...)
 }
 
 // VerifyAndExtractEmail verifies the HMAC-signed state parameter and extracts
@@ -78,8 +123,21 @@ func (m *OAuthManager) hmacSign(data string) string {
 }
 
 // ExchangeCode exchanges an authorization code for a token and persists it.
+// In public client mode, the stored PKCE verifier is consumed (one-use).
 func (m *OAuthManager) ExchangeCode(ctx context.Context, code, userEmail string) (*oauth2.Token, error) {
-	token, err := m.config.Exchange(ctx, code)
+	var opts []oauth2.AuthCodeOption
+
+	if m.publicClient {
+		v, ok := m.pkceVerifiers.LoadAndDelete(userEmail)
+		if !ok {
+			return nil, fmt.Errorf(
+				"no PKCE verifier found for %s — restart authentication from the MCP client", userEmail,
+			)
+		}
+		opts = append(opts, oauth2.SetAuthURLParam("code_verifier", v.(string)))
+	}
+
+	token, err := m.config.Exchange(ctx, code, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging auth code: %w", err)
 	}
@@ -97,4 +155,21 @@ func (m *OAuthManager) Config() *oauth2.Config {
 // TokenStore returns the underlying token store.
 func (m *OAuthManager) TokenStore() TokenStore {
 	return m.tokenStore
+}
+
+// generatePKCEVerifier creates a RFC 7636-compliant code verifier:
+// 32 random bytes encoded as base64url without padding → 43 characters.
+func generatePKCEVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generating PKCE verifier: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// pkceS256Challenge computes the PKCE S256 code challenge from a verifier:
+// BASE64URL(SHA256(verifier)) without padding.
+func pkceS256Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
 }

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -1,11 +1,21 @@
 package auth
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
 func TestSignAndVerifyState(t *testing.T) {
-	mgr := NewOAuthManager("client-id", "client-secret", "http://localhost/callback", []string{"scope"}, nil)
+	mgr := NewOAuthManager("client-id", "client-secret", "http://localhost/callback", false, []string{"scope"}, nil)
 
 	tests := []struct {
 		name  string
@@ -36,7 +46,7 @@ func TestSignAndVerifyState(t *testing.T) {
 }
 
 func TestVerifyAndExtractEmail_Invalid(t *testing.T) {
-	mgr := NewOAuthManager("client-id", "client-secret", "http://localhost/callback", []string{"scope"}, nil)
+	mgr := NewOAuthManager("client-id", "client-secret", "http://localhost/callback", false, []string{"scope"}, nil)
 
 	tests := []struct {
 		name  string
@@ -59,8 +69,8 @@ func TestVerifyAndExtractEmail_Invalid(t *testing.T) {
 }
 
 func TestDifferentSecrets(t *testing.T) {
-	mgr1 := NewOAuthManager("id", "secret1", "http://localhost/callback", nil, nil)
-	mgr2 := NewOAuthManager("id", "secret2", "http://localhost/callback", nil, nil)
+	mgr1 := NewOAuthManager("id", "secret1", "http://localhost/callback", false, nil, nil)
+	mgr2 := NewOAuthManager("id", "secret2", "http://localhost/callback", false, nil, nil)
 
 	state := mgr1.signState("user@example.com")
 
@@ -72,5 +82,138 @@ func TestDifferentSecrets(t *testing.T) {
 	// Different secret should fail
 	if _, ok := mgr2.VerifyAndExtractEmail(state); ok {
 		t.Error("expected mgr2 to reject mgr1's state")
+	}
+}
+
+// TestAUTH01_PKCE_AuthURL_ContainsChallenge verifies AC3: public client auth URL includes S256 PKCE params.
+func TestAUTH01_PKCE_AuthURL_ContainsChallenge(t *testing.T) {
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, nil)
+	url := mgr.GetAuthURL("user@example.com")
+
+	if url == "" {
+		t.Fatal("expected non-empty auth URL")
+	}
+	if !strings.Contains(url, "code_challenge=") {
+		t.Errorf("expected code_challenge in PKCE auth URL, got: %s", url)
+	}
+	if !strings.Contains(url, "code_challenge_method=S256") {
+		t.Errorf("expected code_challenge_method=S256 in PKCE auth URL, got: %s", url)
+	}
+}
+
+// TestAUTH01_ConfidentialMode_NoPKCE verifies AC3: confidential mode auth URL has no PKCE params.
+func TestAUTH01_ConfidentialMode_NoPKCE(t *testing.T) {
+	mgr := NewOAuthManager("client-id", "secret", "http://localhost/callback", false, []string{"scope"}, nil)
+	url := mgr.GetAuthURL("user@example.com")
+
+	if strings.Contains(url, "code_challenge=") {
+		t.Errorf("expected no code_challenge in confidential client auth URL, got: %s", url)
+	}
+	if strings.Contains(url, "code_verifier=") {
+		t.Errorf("expected no code_verifier in confidential client auth URL, got: %s", url)
+	}
+}
+
+// TestAUTH01_PKCE_VerifierStoredAfterAuthURL verifies that a PKCE verifier is stored per-user after GetAuthURL.
+func TestAUTH01_PKCE_VerifierStoredAfterAuthURL(t *testing.T) {
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, nil)
+	mgr.GetAuthURL("user@example.com")
+
+	if _, ok := mgr.pkceVerifiers.Load("user@example.com"); !ok {
+		t.Error("expected PKCE verifier to be stored after GetAuthURL")
+	}
+}
+
+// TestAUTH01_PKCE_Exchange_SendsVerifier verifies AC3: ExchangeCode sends code_verifier for public clients,
+// and that the verifier matches the challenge from the auth URL (challenge = BASE64URL(SHA256(verifier))).
+func TestAUTH01_PKCE_Exchange_SendsVerifier(t *testing.T) {
+	var gotVerifier string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("parse form: %v", err)
+			return
+		}
+		gotVerifier = r.FormValue("code_verifier")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"tok","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer ts.Close()
+
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, NewInMemoryTokenStore())
+	// Override token endpoint to point at test server.
+	mgr.config.Endpoint = oauth2.Endpoint{TokenURL: ts.URL}
+
+	// GetAuthURL stores the PKCE verifier and embeds the challenge in the URL.
+	authURL := mgr.GetAuthURL("user@example.com")
+
+	// Extract code_challenge from the auth URL for later verification.
+	parsed, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parsing auth URL: %v", err)
+	}
+	wantChallenge := parsed.Query().Get("code_challenge")
+	if wantChallenge == "" {
+		t.Fatal("expected code_challenge in auth URL")
+	}
+
+	_, err = mgr.ExchangeCode(context.Background(), "test-code", "user@example.com")
+	if err != nil {
+		t.Fatalf("ExchangeCode error: %v", err)
+	}
+	if gotVerifier == "" {
+		t.Fatal("expected code_verifier in token request for public client mode")
+	}
+
+	// Verify challenge/verifier consistency: challenge == BASE64URL(SHA256(verifier))
+	sum := sha256.Sum256([]byte(gotVerifier))
+	gotChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	if gotChallenge != wantChallenge {
+		t.Errorf("challenge/verifier mismatch: recomputed challenge %q, auth URL had %q", gotChallenge, wantChallenge)
+	}
+}
+
+// TestAUTH01_PKCE_ExchangeWithoutPriorAuth_Fails verifies that Exchange fails if no verifier was stored.
+func TestAUTH01_PKCE_ExchangeWithoutPriorAuth_Fails(t *testing.T) {
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, NewInMemoryTokenStore())
+
+	_, err := mgr.ExchangeCode(context.Background(), "test-code", "never-authed@example.com")
+	if err == nil {
+		t.Error("expected error when no PKCE verifier is stored for user")
+	}
+}
+
+// TestAUTH01_PKCE_VerifierClearedAfterExchange verifies verifier is consumed (one-use) after exchange.
+func TestAUTH01_PKCE_VerifierClearedAfterExchange(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"tok","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer ts.Close()
+
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, NewInMemoryTokenStore())
+	mgr.config.Endpoint = oauth2.Endpoint{TokenURL: ts.URL}
+
+	mgr.GetAuthURL("user@example.com")
+	_, _ = mgr.ExchangeCode(context.Background(), "test-code", "user@example.com")
+
+	// Second exchange for same user should fail (verifier consumed).
+	_, err := mgr.ExchangeCode(context.Background(), "test-code-2", "user@example.com")
+	if err == nil {
+		t.Error("expected error on second exchange attempt — verifier should be consumed")
+	}
+}
+
+// TestAUTH01_PublicClient_StateVerifiesCorrectly verifies AC2: state HMAC works even without a client secret.
+func TestAUTH01_PublicClient_StateVerifiesCorrectly(t *testing.T) {
+	mgr := NewOAuthManager("client-id", "", "http://localhost/callback", true, []string{"scope"}, nil)
+	email := "pub@example.com"
+
+	state := mgr.signState(email)
+	got, ok := mgr.VerifyAndExtractEmail(state)
+	if !ok {
+		t.Fatal("expected state verification to succeed for public client (random HMAC key)")
+	}
+	if got != email {
+		t.Errorf("expected email %q, got %q", email, got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,9 @@ type Config struct {
 		ClientID     string
 		ClientSecret string
 		RedirectURL  string
+		// PublicClient enables PKCE-based OAuth without a client secret.
+		// Set GOOGLE_OAUTH_PUBLIC_CLIENT=true to activate.
+		PublicClient bool
 	}
 	Server struct {
 		Transport string
@@ -41,6 +44,7 @@ func Load() (*Config, error) {
 	// Environment variables
 	cfg.OAuth.ClientID = os.Getenv("GOOGLE_OAUTH_CLIENT_ID")
 	cfg.OAuth.ClientSecret = os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+	cfg.OAuth.PublicClient = envBool("GOOGLE_OAUTH_PUBLIC_CLIENT")
 	cfg.CSEID = os.Getenv("GOOGLE_CSE_ID")
 
 	cfg.CredentialsDir = os.Getenv("WORKSPACE_MCP_CREDENTIALS_DIR")
@@ -92,6 +96,7 @@ func Load() (*Config, error) {
 	flag.StringVar(&cfg.ToolTier, "tool-tier", cfg.ToolTier, "Load tools by tier: core, extended, or complete")
 	flag.BoolVar(&cfg.ReadOnly, "read-only", cfg.ReadOnly, "Request only read-only scopes, disable write tools")
 	flag.BoolVar(&cfg.PersistentAuth, "persistent-auth", cfg.PersistentAuth, "Persist OAuth tokens to disk (survives restarts)")
+	flag.BoolVar(&cfg.OAuth.PublicClient, "public-client", cfg.OAuth.PublicClient, "Use public OAuth client with PKCE (no client secret required)")
 	flag.Parse()
 
 	// CLI --tools flag overrides (not appends to) the ENABLED_SERVICES env var.
@@ -114,8 +119,8 @@ func Load() (*Config, error) {
 	if cfg.OAuth.ClientID == "" {
 		return nil, fmt.Errorf("GOOGLE_OAUTH_CLIENT_ID environment variable is required")
 	}
-	if cfg.OAuth.ClientSecret == "" {
-		return nil, fmt.Errorf("GOOGLE_OAUTH_CLIENT_SECRET environment variable is required")
+	if err := validateOAuthMode(cfg); err != nil {
+		return nil, err
 	}
 
 	// Build OAuth redirect URL
@@ -140,4 +145,19 @@ func envOrDefault(key, def string) string {
 func envBool(key string) bool {
 	v := strings.ToLower(os.Getenv(key))
 	return v == "true" || v == "1" || v == "yes"
+}
+
+// validateOAuthMode checks that the OAuth credential configuration is internally consistent.
+// Confidential clients require a client secret; public clients (PKCE) do not.
+func validateOAuthMode(cfg *Config) error {
+	if cfg.OAuth.PublicClient {
+		return nil
+	}
+	if cfg.OAuth.ClientSecret == "" {
+		return fmt.Errorf(
+			"GOOGLE_OAUTH_CLIENT_SECRET is required for confidential client mode; " +
+				"set GOOGLE_OAUTH_PUBLIC_CLIENT=true to use a public (secretless) client with PKCE",
+		)
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+// TestAUTH01_ConfidentialClientMode verifies AC1: ID + secret → success, PublicClient=false.
+func TestAUTH01_ConfidentialClientMode(t *testing.T) {
+	cfg := &Config{}
+	cfg.OAuth.ClientID = "test-id"
+	cfg.OAuth.ClientSecret = "test-secret"
+	cfg.OAuth.PublicClient = false
+
+	if err := validateOAuthMode(cfg); err != nil {
+		t.Fatalf("expected success for confidential mode: %v", err)
+	}
+}
+
+// TestAUTH01_PublicClientMode verifies AC2: public client mode works without a secret.
+func TestAUTH01_PublicClientMode(t *testing.T) {
+	cfg := &Config{}
+	cfg.OAuth.ClientID = "test-id"
+	cfg.OAuth.PublicClient = true
+	// ClientSecret intentionally empty
+
+	if err := validateOAuthMode(cfg); err != nil {
+		t.Fatalf("expected success for public client mode: %v", err)
+	}
+}
+
+// TestAUTH01_MissingSecret_ConfidentialMode verifies AC1: missing secret in confidential mode → error.
+func TestAUTH01_MissingSecret_ConfidentialMode(t *testing.T) {
+	cfg := &Config{}
+	cfg.OAuth.ClientID = "test-id"
+	cfg.OAuth.PublicClient = false
+	// ClientSecret intentionally empty
+
+	if err := validateOAuthMode(cfg); err == nil {
+		t.Error("expected error when GOOGLE_OAUTH_CLIENT_SECRET is missing in confidential mode")
+	}
+}
+
+// TestAUTH01_PublicClient_SecretIgnored verifies that a secret can coexist with public client mode
+// without causing an error (operators may set both during migration).
+func TestAUTH01_PublicClient_SecretIgnored(t *testing.T) {
+	cfg := &Config{}
+	cfg.OAuth.ClientID = "test-id"
+	cfg.OAuth.ClientSecret = "test-secret"
+	cfg.OAuth.PublicClient = true
+
+	if err := validateOAuthMode(cfg); err != nil {
+		t.Fatalf("expected success when both secret and public client flag are set: %v", err)
+	}
+}

--- a/internal/middleware/auth_enhancer_test.go
+++ b/internal/middleware/auth_enhancer_test.go
@@ -19,6 +19,7 @@ func testOAuthMgr() *auth.OAuthManager {
 		"test-client-id",
 		"test-client-secret",
 		"http://localhost:8000/oauth/callback",
+		false, // confidential client (secret-based)
 		[]string{"https://www.googleapis.com/auth/gmail.readonly"},
 		nil, // token store not used for URL generation
 	)

--- a/internal/tools/drive/drive.go
+++ b/internal/tools/drive/drive.go
@@ -51,7 +51,7 @@ func Register(server *mcp.Server, factory *services.Factory) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "create_drive_file",
 		Icons:       serviceIcons,
-		Description: "Create a new file in Google Drive with optional content. Supports text files and Google Workspace native types.",
+		Description: "Create a new file in Google Drive with optional content. Supports plain text (content), binary uploads via Base64 (content_base64) for PDF, Office, images, etc., empty placeholder files, and Google Workspace native MIME types.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:         "Create Drive File",
 			OpenWorldHint: ptr.Bool(true),
@@ -116,7 +116,7 @@ func Register(server *mcp.Server, factory *services.Factory) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "update_drive_file",
 		Icons:       serviceIcons,
-		Description: "Update a file's name, content, or location in Google Drive.",
+		Description: "Update a file's name, content, or location in Google Drive. Content may be plain text (content) or Base64-encoded bytes (content_base64) for binaries such as PDF or DOCX.",
 		Annotations: &mcp.ToolAnnotations{
 			Title:          "Update Drive File",
 			IdempotentHint: true,

--- a/internal/tools/drive/handlers.go
+++ b/internal/tools/drive/handlers.go
@@ -1,6 +1,7 @@
 package drive
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
 
 	"github.com/evert/google-workspace-mcp-go/internal/middleware"
 	"github.com/evert/google-workspace-mcp-go/internal/pkg/office"
@@ -247,11 +249,12 @@ func createGetDownloadURLHandler(factory *services.Factory) mcp.ToolHandlerFor[G
 // --- create_drive_file ---
 
 type CreateFileInput struct {
-	UserEmail string `json:"user_google_email" jsonschema:"required" jsonschema_description:"The user's Google email address"`
-	FileName  string `json:"file_name" jsonschema:"required" jsonschema_description:"Name for the new file"`
-	Content   string `json:"content,omitempty" jsonschema_description:"Text content to write to the file"`
-	FolderID  string `json:"folder_id,omitempty" jsonschema_description:"ID of the parent folder (default: root)"`
-	MimeType  string `json:"mime_type,omitempty" jsonschema_description:"MIME type of the file (default: text/plain)"`
+	UserEmail     string `json:"user_google_email" jsonschema:"required" jsonschema_description:"The user's Google email address"`
+	FileName      string `json:"file_name" jsonschema:"required" jsonschema_description:"Name for the new file"`
+	Content       string `json:"content,omitempty" jsonschema_description:"Text content to write to the file (mutually exclusive with content_base64)"`
+	ContentBase64 string `json:"content_base64,omitempty" jsonschema_description:"Base64-encoded file bytes (standard or URL-safe). For PDF, Office, images, etc. Cannot be combined with content. Max decoded size 50 MiB. Set mime_type or use a file_name with a known extension (e.g. .pdf, .docx)."`
+	FolderID      string `json:"folder_id,omitempty" jsonschema_description:"ID of the parent folder (default: root)"`
+	MimeType      string `json:"mime_type,omitempty" jsonschema_description:"MIME type of the file (default: text/plain for text uploads; required for binary if file_name has no known extension)"`
 }
 
 func createCreateFileHandler(factory *services.Factory) mcp.ToolHandlerFor[CreateFileInput, any] {
@@ -261,27 +264,55 @@ func createCreateFileHandler(factory *services.Factory) mcp.ToolHandlerFor[Creat
 			return nil, nil, middleware.HandleGoogleAPIError(err)
 		}
 
-		if input.MimeType == "" {
-			input.MimeType = "text/plain"
+		hasText := input.Content != ""
+		hasB64 := driveBase64PayloadNonEmpty(input.ContentBase64)
+		if hasText && hasB64 {
+			return nil, nil, fmt.Errorf("provide only one of content or content_base64, not both")
+		}
+
+		var decoded []byte
+		if hasB64 {
+			decoded, err = decodeDriveContentBase64(input.ContentBase64, office.MaxFileSize)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		mimeType := strings.TrimSpace(input.MimeType)
+		if hasB64 {
+			mimeType = resolveDriveUploadMimeType(mimeType, input.FileName)
+			if mimeType == "" {
+				return nil, nil, fmt.Errorf("binary upload requires mime_type or a file_name with a known extension (e.g. .pdf, .docx)")
+			}
+		} else if mimeType == "" {
+			mimeType = "text/plain"
 		}
 
 		fileMetadata := &drive.File{
 			Name:     input.FileName,
-			MimeType: input.MimeType,
+			MimeType: mimeType,
 		}
 		if input.FolderID != "" {
 			fileMetadata.Parents = []string{input.FolderID}
 		}
 
 		var created *drive.File
-		if input.Content != "" {
+		switch {
+		case hasB64:
+			created, err = srv.Files.Create(fileMetadata).
+				Media(bytes.NewReader(decoded), googleapi.ContentType(mimeType)).
+				Fields("id, name, mimeType, webViewLink").
+				SupportsAllDrives(true).
+				Context(ctx).
+				Do()
+		case hasText:
 			created, err = srv.Files.Create(fileMetadata).
 				Media(strings.NewReader(input.Content)).
 				Fields("id, name, mimeType, webViewLink").
 				SupportsAllDrives(true).
 				Context(ctx).
 				Do()
-		} else {
+		default:
 			created, err = srv.Files.Create(fileMetadata).
 				Fields("id, name, mimeType, webViewLink").
 				SupportsAllDrives(true).

--- a/internal/tools/drive/handlers_extended.go
+++ b/internal/tools/drive/handlers_extended.go
@@ -1,14 +1,17 @@
 package drive
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/googleapi"
 
 	"github.com/evert/google-workspace-mcp-go/internal/middleware"
+	"github.com/evert/google-workspace-mcp-go/internal/pkg/office"
 	"github.com/evert/google-workspace-mcp-go/internal/pkg/response"
 	"github.com/evert/google-workspace-mcp-go/internal/pkg/validate"
 	"github.com/evert/google-workspace-mcp-go/internal/services"
@@ -136,11 +139,13 @@ func createCopyFileHandler(factory *services.Factory) mcp.ToolHandlerFor[CopyFil
 // --- update_drive_file (extended) ---
 
 type UpdateFileInput struct {
-	UserEmail    string `json:"user_google_email" jsonschema:"required" jsonschema_description:"The user's Google email address"`
-	FileID       string `json:"file_id" jsonschema:"required" jsonschema_description:"The file ID to update"`
-	Name         string `json:"name,omitempty" jsonschema_description:"New file name"`
-	Content      string `json:"content,omitempty" jsonschema_description:"New text content (replaces file content)"`
-	MoveToFolder string `json:"move_to_folder,omitempty" jsonschema_description:"Folder ID to move file to"`
+	UserEmail     string `json:"user_google_email" jsonschema:"required" jsonschema_description:"The user's Google email address"`
+	FileID        string `json:"file_id" jsonschema:"required" jsonschema_description:"The file ID to update"`
+	Name          string `json:"name,omitempty" jsonschema_description:"New file name"`
+	Content       string `json:"content,omitempty" jsonschema_description:"New text content (replaces file content; mutually exclusive with content_base64)"`
+	ContentBase64 string `json:"content_base64,omitempty" jsonschema_description:"Base64-encoded bytes replacing file content (standard or URL-safe). Cannot be combined with content. Max decoded size 50 MiB."`
+	MimeType      string `json:"mime_type,omitempty" jsonschema_description:"MIME type for the uploaded bytes when using content_base64; if omitted, inferred from name or the file's metadata in Drive"`
+	MoveToFolder  string `json:"move_to_folder,omitempty" jsonschema_description:"Folder ID to move file to"`
 }
 
 func createUpdateFileHandler(factory *services.Factory) mcp.ToolHandlerFor[UpdateFileInput, any] {
@@ -148,6 +153,20 @@ func createUpdateFileHandler(factory *services.Factory) mcp.ToolHandlerFor[Updat
 		srv, err := factory.Drive(ctx, input.UserEmail)
 		if err != nil {
 			return nil, nil, middleware.HandleGoogleAPIError(err)
+		}
+
+		hasText := input.Content != ""
+		hasB64 := driveBase64PayloadNonEmpty(input.ContentBase64)
+		if hasText && hasB64 {
+			return nil, nil, fmt.Errorf("provide only one of content or content_base64, not both")
+		}
+
+		var decoded []byte
+		if hasB64 {
+			decoded, err = decodeDriveContentBase64(input.ContentBase64, office.MaxFileSize)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		fileMetadata := &drive.File{}
@@ -160,7 +179,28 @@ func createUpdateFileHandler(factory *services.Factory) mcp.ToolHandlerFor[Updat
 			Fields("id, name, mimeType, webViewLink").
 			Context(ctx)
 
-		if input.Content != "" {
+		if hasB64 {
+			mimeType := strings.TrimSpace(input.MimeType)
+			mimeType = resolveDriveUploadMimeType(mimeType, input.Name)
+			if mimeType == "" {
+				existingMeta, gerr := srv.Files.Get(input.FileID).Fields("mimeType", "name").SupportsAllDrives(true).Context(ctx).Do()
+				if gerr != nil {
+					return nil, nil, middleware.HandleGoogleAPIError(gerr)
+				}
+				candidateName := input.Name
+				if candidateName == "" {
+					candidateName = existingMeta.Name
+				}
+				mimeType = resolveDriveUploadMimeType("", candidateName)
+				if mimeType == "" {
+					mimeType = existingMeta.MimeType
+				}
+			}
+			if mimeType == "" {
+				mimeType = "application/octet-stream"
+			}
+			call = call.Media(bytes.NewReader(decoded), googleapi.ContentType(mimeType))
+		} else if hasText {
 			call = call.Media(strings.NewReader(input.Content))
 		}
 

--- a/internal/tools/drive/helpers.go
+++ b/internal/tools/drive/helpers.go
@@ -1,7 +1,9 @@
 package drive
 
 import (
+	"encoding/base64"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"google.golang.org/api/drive/v3"
@@ -142,4 +144,95 @@ func isGoogleNativeType(mimeType string) bool {
 // isOfficeType returns true if the MIME type is a Microsoft Office XML format.
 func isOfficeType(mimeType string) bool {
 	return office.IsOfficeType(mimeType)
+}
+
+// driveBase64PayloadNonEmpty reports whether content_base64 carries non-whitespace payload.
+func driveBase64PayloadNonEmpty(s string) bool {
+	return normalizeBase64Payload(s) != ""
+}
+
+func normalizeBase64Payload(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	return s
+}
+
+// decodeDriveContentBase64 decodes standard or URL-safe base64 (RFC 4648) after stripping
+// common whitespace from pasted payloads. Enforces maxDecodedBytes on the decoded length.
+func decodeDriveContentBase64(s string, maxDecodedBytes int) ([]byte, error) {
+	payload := normalizeBase64Payload(s)
+	if payload == "" {
+		return nil, fmt.Errorf("content_base64 is empty")
+	}
+	var (
+		dec []byte
+		err error
+	)
+	if dec, err = base64.StdEncoding.DecodeString(payload); err != nil {
+		if dec, err = base64.URLEncoding.DecodeString(payload); err != nil {
+			dec, err = base64.RawURLEncoding.DecodeString(payload)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("content_base64: decode failed (use standard or URL-safe base64): %w", err)
+	}
+	if len(dec) > maxDecodedBytes {
+		return nil, fmt.Errorf("decoded file exceeds maximum size (%d bytes; max %d)", len(dec), maxDecodedBytes)
+	}
+	return dec, nil
+}
+
+// mimeTypeFromFileExtension returns a MIME type for well-known extensions, or "" if unknown.
+func mimeTypeFromFileExtension(name string) string {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".pdf":
+		return "application/pdf"
+	case ".docx":
+		return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+	case ".doc":
+		return "application/msword"
+	case ".xlsx":
+		return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+	case ".xls":
+		return "application/vnd.ms-excel"
+	case ".pptx":
+		return "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+	case ".ppt":
+		return "application/vnd.ms-powerpoint"
+	case ".zip":
+		return "application/zip"
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".txt":
+		return "text/plain"
+	case ".csv":
+		return "text/csv"
+	case ".json":
+		return "application/json"
+	case ".xml":
+		return "application/xml"
+	case ".mp4":
+		return "video/mp4"
+	case ".mp3":
+		return "audio/mpeg"
+	default:
+		return ""
+	}
+}
+
+// resolveDriveUploadMimeType returns explicit MIME when set, otherwise from the file name extension.
+func resolveDriveUploadMimeType(explicitMime, fileName string) string {
+	if strings.TrimSpace(explicitMime) != "" {
+		return strings.TrimSpace(explicitMime)
+	}
+	return mimeTypeFromFileExtension(fileName)
 }

--- a/internal/tools/drive/helpers_test.go
+++ b/internal/tools/drive/helpers_test.go
@@ -1,6 +1,7 @@
 package drive
 
 import (
+	"encoding/base64"
 	"testing"
 
 	gdrive "google.golang.org/api/drive/v3"
@@ -113,5 +114,68 @@ func TestMimeTypeForExport(t *testing.T) {
 	got = mimeTypeForExport("text/plain")
 	if got != "" {
 		t.Errorf("got %q, want empty for non-google type", got)
+	}
+}
+
+func TestMimeTypeFromFileExtension(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"a.pdf", "application/pdf"},
+		{"b.DOCX", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"},
+		{"noext", ""},
+	}
+	for _, tt := range tests {
+		if got := mimeTypeFromFileExtension(tt.name); got != tt.want {
+			t.Errorf("mimeTypeFromFileExtension(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestResolveDriveUploadMimeType(t *testing.T) {
+	if got := resolveDriveUploadMimeType("application/pdf", "x.bin"); got != "application/pdf" {
+		t.Errorf("explicit: got %q", got)
+	}
+	if got := resolveDriveUploadMimeType("", "x.pdf"); got != "application/pdf" {
+		t.Errorf("from name: got %q", got)
+	}
+}
+
+func TestDecodeDriveContentBase64(t *testing.T) {
+	raw := []byte{0, 1, 2, 255}
+	std := base64.StdEncoding.EncodeToString(raw)
+	got, err := decodeDriveContentBase64(std, 1024)
+	if err != nil || string(got) != string(raw) {
+		t.Fatalf("std: err=%v got=%v", err, got)
+	}
+	url := base64.RawURLEncoding.EncodeToString(raw)
+	got, err = decodeDriveContentBase64(url, 1024)
+	if err != nil || string(got) != string(raw) {
+		t.Fatalf("rawurl: err=%v got=%v", err, got)
+	}
+	withNL := "\n " + std + " \t"
+	got, err = decodeDriveContentBase64(withNL, 1024)
+	if err != nil || string(got) != string(raw) {
+		t.Fatalf("whitespace: err=%v got=%v", err, got)
+	}
+	if _, err := decodeDriveContentBase64("", 1024); err == nil {
+		t.Fatal("empty payload: want error")
+	}
+	if _, err := decodeDriveContentBase64("@@@", 1024); err == nil {
+		t.Fatal("invalid base64: want error")
+	}
+	largePayload := base64.StdEncoding.EncodeToString([]byte{1, 2, 3, 4, 5})
+	if _, err := decodeDriveContentBase64(largePayload, 4); err == nil {
+		t.Fatal("oversize decoded: want error")
+	}
+}
+
+func TestDriveBase64PayloadNonEmpty(t *testing.T) {
+	if !driveBase64PayloadNonEmpty(" YWJj ") { // "abc"
+		t.Fatal("expected non-empty")
+	}
+	if driveBase64PayloadNonEmpty("  \n\t  ") {
+		t.Fatal("expected empty")
 	}
 }


### PR DESCRIPTION
## Summary

- **PKCE S256 support** for public OAuth clients — operators set `GOOGLE_OAUTH_PUBLIC_CLIENT=true` (or `--public-client`) to run without `GOOGLE_OAUTH_CLIENT_SECRET`
- RFC 7636-compliant verifier/challenge lifecycle: generated in `GetAuthURL`, consumed (one-use) in `ExchangeCode` via `sync.Map.LoadAndDelete`
- Random 32-byte HMAC key for OAuth state signing when no client secret is available
- Confidential-client mode (ID + secret) is fully unchanged
- Operator docs updated: `docs/configuration.md`, `docs/auth-and-scopes.md`, `README.md`, `.env.example`

### Files changed (AUTH-01 surface)

| Package | Files | Change |
|---------|-------|--------|
| `internal/config` | `config.go`, `config_test.go` (new) | `PublicClient` field, `GOOGLE_OAUTH_PUBLIC_CLIENT` env, `--public-client` flag, `validateOAuthMode` |
| `internal/auth` | `oauth.go`, `oauth_test.go` | PKCE verifier/challenge, `publicClient` + `pkceVerifiers sync.Map`, random state key, 7 new tests |
| `cmd/server` | `main.go` | Pass `PublicClient` to `NewOAuthManager`, log OAuth mode |
| `internal/middleware` | `auth_enhancer_test.go` | Updated `NewOAuthManager` call signature |
| docs | `auth-and-scopes.md`, `configuration.md`, `README.md`, `.env.example`, `CHANGELOG.md` | Public client mode docs, Google Console setup guidance |
| roadmap | `AUTH-01-pkce-public-client.md` | Status → Done, all ACs checked off |

Also includes `.claude/` project infrastructure (commands, skills, agents).

## Test plan

- [x] `go test -race ./...` — all packages pass
- [x] `golangci-lint run` — clean on changed packages
- [x] Podman smoke test — image builds, server starts, `/mcp` (405) and `/oauth/callback` (400) respond
- [x] 4 config tests: confidential mode, public mode, missing secret error, secret+public coexistence
- [x] 7 PKCE tests: challenge in URL, no PKCE in confidential, verifier stored, exchange sends verifier with challenge/verifier consistency check, exchange-without-auth fails, verifier consumed after exchange, public-client state HMAC works
- [x] Review findings addressed: CLI flag, concurrent verifier overwrite warning, idiomatic `var opts`, challenge/verifier consistency assertion, PRNG failure logging, operator docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)